### PR TITLE
fix(discord-bot): Fix Victory Lap bot list_recent_prs parameter

### DIFF
--- a/discord-bot/bots/victory_lap.py
+++ b/discord-bot/bots/victory_lap.py
@@ -169,7 +169,12 @@ class VictoryLapBot:
 
             # Get recently merged PRs (last check interval window)
             lookback_hours = max(1, self.check_interval_minutes // 60 + 1)
-            recent_prs = await self.github.list_recent_prs(hours=lookback_hours)
+            merged_since = datetime.utcnow() - timedelta(hours=lookback_hours)
+            recent_prs = await self.github.list_recent_prs(
+                state="closed",
+                merged_since=merged_since,
+                per_page=30
+            )
 
             # Filter to PRs we haven't celebrated yet
             uncelebrated_prs = []


### PR DESCRIPTION
- Change from hours=lookback_hours to merged_since parameter
- Calculate datetime using timedelta instead of passing hours
- Matches GitHubAPIDirectImplementation.list_recent_prs() signature
- Fixes TypeError: got an unexpected keyword argument 'hours'