### PR TITLE
feat: Add 9 "From Inver:" facilitation callouts to IM Handbook

### DIFF
--- a/im-handbook/chapters/00-facilitation-philosophy.qmd
+++ b/im-handbook/chapters/00-facilitation-philosophy.qmd
@@ -119,6 +119,14 @@ When energy drops: *"What's at stake if we don't solve this problem?"*
 - **All the answers:** Questions are more valuable than solutions
 - **Complex preparation:** Trust the framework and your participants
 
+::: {.im-inver}
+::: {.callout-tip title="From Inver: Your domain expertise IS the scenario's expertise"}
+I'm a privacy attorney, not a cybersecurity professional. What I brought was regulatory knowledge -- specific deadline provisions, what makes something a reportable breach, why the incident/breach distinction matters legally. I invoked those by article number because that's how real compliance conversations happen.
+
+Players with legal or compliance backgrounds immediately recognized it. Players without them learned something real under pressure. You don't need to be a cybersecurity expert to run a great M&M session -- you need to know your domain well enough to make the stakes feel authentic.
+:::
+:::
+
 #### 5-Minute Session Prep
 
 **Choose Your Malmon:**

--- a/im-handbook/chapters/07-containment-mechanics.qmd
+++ b/im-handbook/chapters/07-containment-mechanics.qmd
@@ -228,12 +228,14 @@ The tracks influence each other realistically:
 **Network Security Track Adjustments:**
 
 *Decrease (-5 to -25):*
+
 - Malware spreads to additional systems (-10)
 - Critical vulnerability discovered (-15)
 - Security control bypassed or fails (-20)
 - Threat evolves to new stage (-25)
 
 *Increase (+5 to +20):*
+
 - Successful threat containment (+15)
 - Vulnerabilities patched effectively (+10)
 - Security controls strengthened (+20)
@@ -242,26 +244,38 @@ The tracks influence each other realistically:
 **IR Effectiveness Track Adjustments:**
 
 *Decrease (-5 to -20):*
+
 - Team roles conflict or duplicate effort (-10)
 - Investigation goes off-track (-15)
 - Poor communication between roles (-20)
 - Key information missed or ignored (-25)
 
 *Increase (+5 to +20):*
+
 - Excellent role coordination (+15)
 - Breakthrough investigation discovery (+20)
 - Clear, effective communication (+10)
 - Collaborative problem-solving (+25)
 
+::: {.im-inver}
+::: {.callout-tip title="From Inver: Connect the mechanical reward to the Malmon"}
+When my team finally got two conflicting departments talking to each other, I gave everyone a +3 for the rest of the session -- and I said out loud that it was because working together is one of this Malmon's weaknesses.
+
+The players weren't just succeeding at teamwork. They were exploiting the enemy. That connection -- between the learning objective and the in-world fiction -- is what makes the reward feel earned rather than arbitrary.
+:::
+:::
+
 **Business Operations Track Adjustments:**
 
 *Decrease (-5 to -30):*
+
 - Critical systems go offline (-20)
 - Stakeholder confidence lost (-15)
 - Regulatory scrutiny begins (-25)
 - Public disclosure of incident (-30)
 
 *Increase (+5 to +25):*
+
 - Systems restored to operation (+20)
 - Stakeholder confidence rebuilt (+15)
 - Proactive communication success (+10)

--- a/im-handbook/chapters/09-running-sessions.qmd
+++ b/im-handbook/chapters/09-running-sessions.qmd
@@ -235,6 +235,22 @@ Instead of stacking +1 bonuses, some IMs prefer the "advantage" mechanic borrowe
 Neither approach is "correct." Choose based on your preference and group dynamics. Some IMs use +1 stacking for consistency; others prefer advantage for its dramatic feel. Some use both situationally. Experiment to find what works for your table.
 :::
 
+::: {.im-inver}
+::: {.callout-tip title="From Inver: When two players both have a stake, let them both roll"}
+If two players have both contributed meaningfully to the same action, let them each roll and take the higher result. I did this when both my Protector and Crisis Manager had relevant information about a suspicious IP -- they'd both earned the right to attempt it.
+
+It's faster than arbitrating who "gets" the roll, it rewards collaborative thinking, and it almost always results in a better outcome -- which is the point. Teamwork should help.
+:::
+:::
+
+::: {.im-inver}
+::: {.callout-tip title="From Inver: Give advantage when a player does something genuinely clever"}
+When a player makes a particularly smart move -- a creative approach, a well-reasoned argument, a real insight that changes the room -- give them advantage: roll twice, take the higher result. I reserve it for moments that actually deserve it, so it still means something when it happens.
+
+It's a way of saying "yes, that was good" without breaking the fiction to praise them out loud. The dice communicate it for you.
+:::
+:::
+
 **Perfect Teamwork: Automatic Success**
 
 When the entire team demonstrates:
@@ -391,6 +407,14 @@ When the entire team demonstrates:
 
 **Your response:** *"That's brilliant - you're turning the malware's design against itself. This works exactly as you described."*
 
+::: {.im-inver}
+::: {.callout-tip title="From Inver: Not everything deserves a dice roll"}
+A player did some quick research mid-session and reported back what he found. Good information, real contribution. I didn't make him roll for it -- I just said "we'll allow it to be part of the universal canon."
+
+But when he wanted to interpret what that meant for the investigation? That's a roll. The distinction matters: contributing a fact is different from drawing a conclusion. Gating every contribution behind dice slows the table and signals that you don't trust smart play.
+:::
+:::
+
 ### Common Facilitation Mistakes
 
 **Mistake 1: Rolling for Everything**
@@ -516,6 +540,16 @@ When someone rolls badly, I lean into humor rather than gravity. Before a roll, 
 This does two things: it takes the sting out of bad rolls, and it creates running jokes that bond the group. By the end of the session, players were making their own cursed dice comments. They wanted to keep rolling even after bad results because failure had become entertaining.
 
 **Your choice:** Use humor to soften failures if your table enjoys levity, or keep the tone serious if that matches your group's preferences. Some tables thrive on dramatic tension; others need laughter to stay engaged.
+:::
+:::
+
+::: {.im-inver}
+::: {.callout-tip title="From Inver: A nat 1 is a gift, not a punishment"}
+The same player rolled two natural ones in my session. The first time I said: "With your nat one, you have estimated that the vibes are indeed bad currently. Good to know." That got the biggest laugh of the session.
+
+The second time, I opened a help action so a teammate could bail him out. Now it's a team moment instead of a solo humiliation.
+
+Find the absurdist reading. Nat 1 isn't "you fail and feel bad" -- it's "something slightly ridiculous happens and everyone moves on." The player who rolled both ones was fully engaged the whole session.
 :::
 :::
 

--- a/im-handbook/chapters/13-advanced-scenarios.qmd
+++ b/im-handbook/chapters/13-advanced-scenarios.qmd
@@ -228,12 +228,28 @@ Once teams have mastered fundamental Malmon encounters and collaborative respons
 - Allow teams to request specific information based on their investigation priorities
 - Balance realism with manageable information flow
 
+::: {.im-inver}
+::: {.callout-tip title="From Inver: Stage your handouts like a reveal"}
+I put together three numbered folders before the session -- each released at a specific story beat. Folder 1 went out when the anomaly surfaced. Folder 2 when we needed to examine the data export. Folder 3 when exfiltration was confirmed. Players only see what they'd plausibly have in front of them at that moment.
+
+It sounds like extra prep, but it's mostly organization. And the payoff is real: discovery lands differently when players can't skip ahead.
+:::
+:::
+
 **Stakeholder Simulation:**
 
 - Introduce external pressures through simulated stakeholder demands
 - Create tension between different organizational priorities
 - Simulate media pressure and public scrutiny
 - Include regulatory and legal considerations in decision-making
+
+::: {.im-inver}
+::: {.callout-tip title="From Inver: Build the interpersonal conflict into the scenario"}
+My scenario had two teams that distrusted each other -- for realistic reasons. One thought it was purely a compliance problem. The other thought everything is a security problem. That conflict wasn't random friction. It was the central obstacle.
+
+Players had to solve the human problem before they could solve the technical one. When they did, I rewarded it mechanically. Design your NPCs to be in conflict with each other, and let your players be the ones who bridge it.
+:::
+:::
 
 **Time Management:**
 
@@ -250,6 +266,14 @@ Once teams have mastered fundamental Malmon encounters and collaborative respons
 - Encourage teams to consider second and third-order effects
 - Guide discussion of strategic trade-offs and resource allocation
 - Help teams balance immediate response with long-term resilience
+
+::: {.im-inver}
+::: {.callout-tip title="From Inver: Let players discover the distinction through play"}
+One of my players raised the incident/breach distinction mid-session -- technically you're still an "incident" until you can confirm unencrypted personal data actually left. I didn't explain it or shortcut it. I asked: "Are we at a breach here?" and let the team debate it.
+
+Then I had them roll to determine actual scope. The roll confirmed it: millions of user records, transaction history, employee data. That's when they understood what makes something a breach -- not because I told them, but because they lived the confirmation.
+:::
+:::
 
 **Cross-Functional Coordination:**
 


### PR DESCRIPTION
## Summary

Adds 9 first-person "From Inver:" technique callouts across 4 IM Handbook chapters, drawn from Inver's actual facilitation style (privacy attorney and TTRPG designer). No scenario card changes included.

## Callouts placed

| Chapter | Callout title |
|---|---|
| `00-facilitation-philosophy.qmd` | Your domain expertise IS the scenario's expertise |
| `07-containment-mechanics.qmd` | Connect the mechanical reward to the Malmon |
| `09-running-sessions.qmd` | Not everything deserves a dice roll |
| `09-running-sessions.qmd` | A nat 1 is a gift, not a punishment |
| `09-running-sessions.qmd` | When two players both have a stake, let them both roll |
| `09-running-sessions.qmd` | Give advantage when a player does something genuinely clever |
| `13-advanced-scenarios.qmd` | Stage your handouts like a reveal |
| `13-advanced-scenarios.qmd` | Build the interpersonal conflict into the scenario |
| `13-advanced-scenarios.qmd` | Let players discover the distinction through play |

All callouts use `.im-inver` CSS class (blue) with `callout-tip` format, consistent with Joe's existing technique callout pattern.

## Files changed

- `im-handbook/chapters/00-facilitation-philosophy.qmd`
- `im-handbook/chapters/07-containment-mechanics.qmd`
- `im-handbook/chapters/09-running-sessions.qmd`
- `im-handbook/chapters/13-advanced-scenarios.qmd`

## Test plan

- [ ] Verify all 9 Inver callouts render correctly in blue across the four chapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)