### PR TITLE
feat: Add 2 additional From Inver: callouts to running-sessions chapter

### DIFF
--- a/im-handbook/chapters/09-running-sessions.qmd
+++ b/im-handbook/chapters/09-running-sessions.qmd
@@ -251,6 +251,14 @@ It's a way of saying "yes, that was good" without breaking the fiction to praise
 :::
 :::
 
+::: {.im-inver}
+::: {.callout-tip title="From Inver: Let players name their own modifier"}
+When a roll doesn't have an obvious modifier, I ask the player to name the skill they're using. If they can justify it, I'll give it a +2 or +3. If they're stuck, I give them a default.
+
+It takes two seconds and it does real work. The player has to think about what they're actually doing, not just "I roll." When someone argues for a higher modifier because they have real-world experience that applies to the situation, that's exactly the kind of expertise I want surfaced at the table.
+:::
+:::
+
 **Perfect Teamwork: Automatic Success**
 
 When the entire team demonstrates:
@@ -412,6 +420,14 @@ When the entire team demonstrates:
 A player did some quick research mid-session and reported back what he found. Good information, real contribution. I didn't make him roll for it -- I just said "we'll allow it to be part of the universal canon."
 
 But when he wanted to interpret what that meant for the investigation? That's a roll. The distinction matters: contributing a fact is different from drawing a conclusion. Gating every contribution behind dice slows the table and signals that you don't trust smart play.
+:::
+:::
+
+::: {.im-inver}
+::: {.callout-tip title="From Inver: Roll your own dice when the world is uncertain"}
+A player asked whether our vendor was based in Moldova. I hadn't decided. So I rolled my own dice, out loud, in front of everyone. It came up yes.
+
+The player who asked got a visible moment of confirmation -- not "the IM says so," but "the dice says so." When the world feels genuinely undecided until the roll happens, the fiction breathes differently. You don't have to pre-script everything. Sometimes the most authentic answer is to let the world decide alongside your players.
 :::
 :::
 


### PR DESCRIPTION
## Summary

Two additional "From Inver:" facilitation callouts for `im-handbook/chapters/09-running-sessions.qmd`, following up on PR #207.

**Callouts added:**

- **"Let players name their own modifier"** -- When a roll doesn't have an obvious modifier, ask the player to name the skill they're using. If they justify it, give +2 or +3. Surfaces real-world expertise at the table.

- **"Roll your own dice when the world is uncertain"** -- When a world fact hasn't been decided yet, roll openly in front of everyone and let the dice answer. The fiction breathes differently when the world decides alongside the players.

## Files changed

- `im-handbook/chapters/09-running-sessions.qmd` (+16 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)