### PR TITLE
fix: beginner scenario improvements and tent card print CSS

### DIFF
--- a/dev/workspace/CLAUDE.md
+++ b/dev/workspace/CLAUDE.md
@@ -22,11 +22,11 @@ Each Chat History file has a max 5 line summary near the top of the file, and a 
     "The summary of the conversation is here"
     <<<
 
-# Feature: Implement Scenario Variations System
+# Feature: M&M Scenario Enrichment via TabletopExercise MCP Server
 
-**Branch:** `feature/scenario-variations`
-**Started:** `2026-02-05`
-**Issue:** #125
+**Branch:** `feature/scenario-enrichment-mcp`
+**Started:** `2026-03-06`
+**Issue:** #212
 **Status:**
 
 - [x] In Progress
@@ -35,97 +35,87 @@ Each Chat History file has a max 5 line summary near the top of the file, and a 
 
 ## Purpose
 
-Implement a flexible mechanism for scenario variations that allows multiple independent "dimensions" of variation within a single core scenario. The goal is to move beyond static, single-context scenarios and create a framework where users can dynamically change scenario context at run-time (region, industry, difficulty level, technology stack, attack vector).
+Enrich all M&M scenario cards to a unified quality standard using the TabletopExercise MCP server. The enrichment pipeline converts the existing TabletopExercise TypeScript generators (github.com/Arcanum-Sec/TableTop_Skill) into an MCP server, then uses a schema-aware agent prompt to generate `exercise-data.json` from each scenario card QMD and produce professional facilitator/participant HTML.
 
 **Problem:**
-- Scenarios are currently static and location-specific
-- Content duplication across similar scenarios in different contexts
-- Limited reusability and scalability across different regions/industries
-- Content is not relevant to a global audience
+- ~45 of 50 scenario cards lack scripted NPC dialogue, inject sequences, red herrings, gap analysis, and artifact handouts
+- IMs must improvise everything beyond the structural scaffolding
+- No unified quality standard defines what "complete" means for a scenario
 
-**Target Audience:** Incident Masters creating scenarios, players experiencing flexible training scenarios
+**Target Audience:** Incident Masters running sessions; scenario authors enriching cards
 
 ## Scope
 
-Implementation should cover:
+This branch owns the M&M side only. The MCP server code lives in a separate fork of TabletopExercise.
 
-1. **Lua Filter** - Parse variation markdown syntax (`:::variant` divs) and generate structured HTML with data attributes
-2. **JavaScript Switcher** - Render UI controls (dropdowns), manage show/hide logic, persist choices via localStorage
-3. **Markdown Syntax** - Define clean, readable syntax for scenario variations in QMD files
-4. **File Renaming** - Rename scenario files to be more generic (e.g., `lockbit-hospital.qmd` → `lockbit-core.qmd`)
-5. **URL/Navigation Structure** - Update navigation and links to reflect generic scenario names
-6. **Default Variations** - Define sensible defaults (US, Healthcare, Intermediate)
-7. **Testing** - Verify variation switching works across different browsers and devices
+1. **Schema-aware enrichment prompt** -- rewrite `dev/workspace/prompts/scenario-enrich-prompt.md` to use MCP tools
+2. **Pilot enrichment** -- validate pipeline on 3 priority scenarios once MCP server is operational
 
-## Variation Dimensions
+**MCP server work** (tracked here, implemented in TabletopExercise fork):
+- Fork: `github.com/klausagnoletti/TableTop_Skill` feature branch `feature/mcp-server`
+- `schema.ts`: Zod schema defining `exercise-data.json` (the unified quality standard)
+- `mcp-server.ts`: 6 tools + 3 resources via stdio transport
 
-- **Region:** US vs. EU vs. Asia (regulations, currencies, agencies, formats)
-- **Industry/Sector:** Healthcare, Financial Services, Manufacturing, Education
-- **Difficulty Level:** Beginner, Intermediate, Advanced
-- **Technology Stack:** Cloud-Native, On-Premise, Hybrid
-- **Attack Vector:** Ransomware, Supply Chain Attack, Insider Threat
+## Scenario Types
+
+- **Contemporary** (majority): symptom-only hook text, fictional org context, "your organization" debrief framing
+- **Historical Foundation** (Stuxnet, Gh0st RAT, Poison Ivy, Code Red): may name malware, references real events, "what history teaches us" debrief framing
+- **Community** (The Inquisitor): infer rules from `villain-plan` attribute
 
 ## Task Checklist
 
-**Discovery:**
-- [ ] Identify all scenarios that would benefit from variations
-- [ ] Document current scenario naming conventions
-- [ ] Review existing Lua filter architecture (`shared/filters/`)
-- [ ] Understand localStorage patterns in existing JavaScript
+**Phase 1: TabletopExercise MCP Server** (work happens in TabletopExercise fork)
+- [ ] Fork Arcanum-Sec/TableTop_Skill and clone locally
+- [ ] Read actual codebase -- confirm generator API before writing anything
+- [ ] Implement `schema.ts` in fork feature branch
+- [ ] Implement `mcp-server.ts` in fork feature branch
+- [ ] Register with M&M via `claude mcp add tabletop-exercise`
 
-**Technical Implementation:**
-- [ ] Design and implement Lua filter for parsing variation syntax
-- [ ] Create JavaScript switcher module for UI controls and persistence
-- [ ] Test variation syntax rendering in local environment
-- [ ] Test localStorage persistence across pages
+**Phase 2: Enrichment Prompt** (work happens in this branch)
+- [x] Rewrite `dev/workspace/prompts/scenario-enrich-prompt.md` as schema-aware MCP agent workflow
 
-**Content Integration:**
-- [ ] Identify priority scenarios for variation conversion (start with 2-3)
-- [ ] Add variation syntax to selected scenarios
-- [ ] Rename files to generic names (e.g., `lockbit-core.qmd`)
-- [ ] Update `_quarto.yml` navigation with new file names
-- [ ] Update all internal links to scenarios
-
-**Testing & Validation:**
-- [ ] Test variation switching in different browsers
-- [ ] Verify localStorage persistence works correctly
-- [ ] Test mobile responsiveness of variation UI
-- [ ] Verify backward compatibility with existing scenarios
-
-**Documentation:**
-- [ ] Document variation syntax and usage guidelines
-- [ ] Create examples for scenario authors
+**Phase 5: Pilot Enrichment** (blocked until MCP server deployed)
+- [ ] Enrich `lockbit/hospital-emergency`
+- [ ] Enrich `wannacry/hospital-emergency`
+- [ ] Enrich `stuxnet/historical-foundation` (additive only -- handouts exist)
 
 ## Related Issues
 
-- #125 - This issue (Scenario variations system)
-- #7 - Part of Scenario Prep Pro milestone
+- #212 - This epic (M&M Scenario Enrichment via TabletopExercise MCP Server)
+- #213 - Rewrite scenario-enrich-prompt.md as schema-aware MCP agent prompt
+- #214 - Implement TabletopExercise MCP server (schema.ts + mcp-server.ts)
+- #7 - Scenario Prep Pro milestone
 
 ## Key Technical Decisions
 
-### Lua Filter Approach
-- Single global filter (not scenario-specific)
-- Parse `:::variant` divs with `group` and `value` attributes
-- Output HTML divs with `data-group` and `data-value` attributes
-- Hide all non-default variations initially
+### MCP Server Design
+- Official `@modelcontextprotocol/sdk` + Zod only -- no community framework
+- stdio transport -- standard for local agent integration
+- Import `generateStandaloneHTML()` directly from existing generators -- no subprocess spawning
+- `check_scenario_completeness` tool detects present/missing sections and scenario_type from raw QMD
 
-### JavaScript Approach
-- Global module for all variation switching
-- Dropdown/button UI for each variation dimension
-- Show/hide via CSS classes on variation divs
-- localStorage to persist user selections across pages
+### Quality Standard
+- The `ExerciseDataSchema` Zod schema IS the quality standard
+- A scenario is complete when its `exercise-data.json` validates without errors
+- `validate_exercise_data` tool enforces this before any generator call
 
-### File Naming
-- Convert specific names (e.g., `lockbit-hospital.qmd`) to generic cores (e.g., `lockbit-core.qmd`)
-- Variations selected via UI, not in URL
-- Single URL resolves to all possible variations
+### Enrichment Approach
+- Additive only -- never modify existing scenario card content
+- `check_scenario_completeness` first -- generate only missing sections
+- Historical scenarios: `scenario_type: "historical"` unlocks named-malware rule in inject read-aloud
 
 ## Architecture Notes
 
-- Filters: `shared/filters/variant-switcher.lua` (new)
-- JavaScript: `shared/js/scenario-variations.js` (new)
-- This integrates with existing Quarto/JS architecture
-- Leverage existing design tokens and theming system
+- MCP server code: `/home/Klaus/Documents/git/TableTop_Skill/TabletopExercise/generators/` (separate local clone)
+- Prompt: `dev/workspace/prompts/scenario-enrich-prompt.md` (this branch)
+- MCP registration: `claude mcp add tabletop-exercise -- bun run /home/klaus/Documents/git/TableTop_Skill/TabletopExercise/generators/mcp-server.ts`
+- Output per scenario: `facilitator.html` + `participant.html` in the scenario directory
+
+
+## Path Convention
+
+The home directory username is mixed-case and Claude cannot reliably determine the casing.
+**Always use `$HOME` in Bash commands and `realpath ~/...` to get absolute paths before
+passing them to Read/Edit tools.** Never hardcode `/home/...` paths by retyping the username.
 
 ---
-

--- a/im-handbook/resources/im-onboarding/fakebat/index.qmd
+++ b/im-handbook/resources/im-onboarding/fakebat/index.qmd
@@ -16,18 +16,16 @@ scenario-variables:
 
 # FakeBat Beginner Scenario: Friday Deadline
 
-::: {.scenario-card organization="Pixel & Co. (12-person creative agency)" stakes="Client presentation + Agency reputation + Friday deadline" hook="Three workstations show browser hijacking symptoms two days before the agency's biggest ever client pitch. FakeBat was installed via a fake Adobe Flash update prompt on a domain registered six days ago." pressure="- Career-defining client presentation in 48 hours  - Client flying in from Copenhagen -- rescheduling damages the relationship, not just the account  - Two designers lose workstation access if machines are isolated now" malmon="FakeBat" npcs="- Alex (Agency Owner): Calm, practical, already decided -- waiting for permission to act. Taps her notebook on the doorframe when she has made up her mind. *'Tell me what we are dealing with.'*" secrets="- Fake Adobe Flash update served from `adobeupdate-secure.net` (domain registered 6 days ago)  - Malware runs as a scheduled task beaconing C2 every 15 minutes  - Three workstations compromised; file server reachable if C2 instruction arrives before isolation" villain-plan="- Stage 1: FakeBat installed via fake browser update on three workstations, beaconing C2, credential harvest begun [✓]  - Stage 2: C2 server sends lateral movement instruction; FakeBat probes shared file server -- presentation files at risk" adaptation-notes="- First-session IMs: Follow the tutorial callouts in order. Let players discover the fake domain in Handout A before offering Clue 1.  - Experienced IMs running this as a demo: Skip the tutorial callouts and treat as a standard session.  - Small creative agencies are deliberately chosen: no regulatory complexity, relatable deadline pressure, visible symptoms." scenario-type="Downloader" difficulty="Beginner" time-estimate="45-75 minutes"}
+::: {.scenario-card organization="Pixel & Co. (12-person creative agency)" stakes="Client presentation + Agency reputation + Friday deadline" hook="Some workstations show browser hijacking symptoms two days before the agency's biggest ever client pitch." pressure="- Career-defining client presentation in 48 hours  - Client flying in from Copenhagen -- rescheduling damages the relationship, not just the account  - Two designers lose workstation access if machines are isolated now" malmon="FakeBat" npcs="- Alex (Agency Owner): Calm, practical, already decided -- waiting for permission to act. Taps her notebook when she has made up her mind. *'Tell me what we are dealing with.'*" secrets="- Fake Adobe Flash update served from `adobeupdate-secure.net` (domain registered 6 days ago)  - Malware runs as a scheduled task beaconing C2 every 15 minutes  - Three workstations compromised; file server reachable if C2 instruction arrives before isolation" villain-plan="- Stage 1: FakeBat installed via fake browser update on three workstations, beaconing C2, credential harvest begun [✓]  - Stage 2: C2 server sends lateral movement instruction; FakeBat probes shared file server -- presentation files at risk" adaptation-notes="- First-session IMs: Follow the tutorial callouts in order. Let players discover the fake domain in Handout A before offering Clue 1.  - Experienced IMs running this as a demo: Skip the tutorial callouts and treat as a standard session.  - Small creative agencies are deliberately chosen: no regulatory complexity, relatable deadline pressure, visible symptoms." scenario-type="Downloader" difficulty="Beginner" time-estimate="45-75 minutes"}
 :::
 
 ---
 
 ## IM Overview
 
-- **Malmon:** FakeBat
-- **Setting:** Small creative agency (12 employees), Friday client presentation
+- **Malmon:** [FakeBat](../../malmon-details/fakebat.html)
 - **Runtime:** 45-75 minutes (Lunch and Learn)
 - **Players:** 4 (pre-generated team included below)
-- **Difficulty:** First session -- no prior experience required
 
 ::: {.callout-important title="First-Order Rules -- the only things that stay constant"}
 M&M has four rules that never change. Everything else is your style.
@@ -36,7 +34,7 @@ M&M has four rules that never change. Everything else is your style.
    results and evolve the threat.
 
 2. **Success Mechanic:** Simple actions succeed automatically. Complex actions: roll d20,
-   5+ easy, 10+ medium, 15+ hard. (See the d20 callout in Round 1.)
+   5+ easy, 10+ medium, 15+ hard. (See the [d20 callout](#d20-system) in Round 1.)
 
 3. **Collaboration:** Players assisting each other: +1 per assisting player (max +3),
    or roll two dice and take the higher.
@@ -61,10 +59,11 @@ All three resolution endings -- contained, partial, and Stage 2 triggered -- wer
 **Materials needed:**
 
 - This document (print or screen)
-- 1 (or more) x d20 die (players can share - or they have their own)
-- Role cards for: Detective, Protector, Tracker, Communicator
+- Physical d20 dice -- bring a handful (3-5 recommended); players can share one die but everyone rolling their own is more engaging. Digital dice apps exist as a last resort when no physical dice are available.
+- [Role cards](../../role-cards-reference.html) for: Detective, Protector, Tracker, Communicator
+- [Player tent cards](../../../../players-handbook/resources/player-tent-cards.html) (optional -- printable name placards for the table)
 
-**No other preparation required.** Everything -- clues, NPC lines, decision points, and resolution endings -- is scripted below. Read through once before running. If you have 5 extra minutes, read the Setting the Scene box aloud to yourself.
+**No other preparation required.** Everything -- clues, NPC lines, decision points, and resolution endings -- is scripted below. Read through once before running. If you have 5 extra minutes, read the [Setting the Scene](#setting-the-scene) section aloud to yourself.
 
 ::: {.callout-tip title="You cannot break this scenario"}
 Every path through this scenario leads somewhere useful. If players do not contain
@@ -95,19 +94,19 @@ Hand out role cards and ask: "Which of these sounds most like how you would appr
 When the script addresses a clue to a role -- "Tracker, the download logs show..." -- use the player's actual name instead of the role label. Players are themselves in this scenario.
 :::
 
-- **Detective** -- "You always ask who had access and when. Your job is to trace what happened."
+- **[Detective](../../role-cards-reference.html#detective-cyber-sleuth)** -- "You always ask who had access and when. Your job is to trace what happened."
   - *Situational anchor:* You were brought in three weeks ago to audit the agency's systems before the presentation. This is your first real incident.
   - *Play as:* you ask one more question even when the team is ready to act.
 
-- **Protector** -- "Your instinct is to isolate first, ask questions second. You keep the threat from spreading."
+- **[Protector](../../role-cards-reference.html#protector-digital-guardian)** -- "Your instinct is to isolate first, ask questions second. You keep the threat from spreading."
   - *Situational anchor:* You set up this agency's IT two years ago. If something got through, you want to know how.
   - *Play as:* you state the action you want to take, then immediately ask who disagrees.
 
-- **Tracker** -- "You follow the data trail. You want logs and timestamps before anyone acts."
+- **[Tracker](../../role-cards-reference.html#tracker-network-analyst)** -- "You follow the data trail. You want logs and timestamps before anyone acts."
   - *Situational anchor:* You noticed the redirect behavior yesterday but were overruled when you suggested pulling the machines. This morning you were right.
   - *Play as:* you quote a specific number from the evidence before making any recommendation.
 
-- **Communicator** -- "You keep stakeholders calm and the team aligned. You decide what gets communicated and when."
+- **[Communicator](../../role-cards-reference.html#communicator-stakeholder-liaison)** -- "You keep stakeholders calm and the team aligned. You decide what gets communicated and when."
   - *Situational anchor:* Alex called you before IT because you have the client relationship. Your job is to decide what the client hears and when.
   - *Play as:* you repeat back what you heard before responding, especially when the news is bad.
 
@@ -116,7 +115,7 @@ When the script addresses a clue to a role -- "Tracker, the download logs show..
 ## Setting the Scene
 
 ::: {.callout-note title="Read aloud to players"}
-It is Wednesday morning at Pixel and Co., a 12-person creative agency that has spent the last three months producing the campaign of their careers. Friday is the client presentation -- a pitch worth more than everything else in the studio's portfolio combined. Agency owner Alex gathered the team at 9am, but instead of the usual pre-presentation energy, three designers report that their browsers are behaving strangely: search results redirect to unfamiliar sites, ads appear inside design tools, and new toolbar icons showed up overnight. The IT consultant was called in. The team is gathered around the kitchen table. What do you do?
+It is Wednesday morning at Pixel and Co., a 12-person creative agency that has spent the last three months producing the campaign of their careers. Friday is the client presentation -- a pitch worth more than everything else in the studio's portfolio combined. Agency owner Alex gathered the team at 9am, but instead of the usual pre-presentation energy, several designers report that their browsers are behaving strangely: search results redirect to unfamiliar sites, ads appear inside design tools, and new toolbar icons showed up overnight. The IT consultant was called in. The team is gathered around the kitchen table. What do you do?
 :::
 
 ---
@@ -141,7 +140,7 @@ Before you start, explain the three steps to your players:
 That is the whole game. Everything else builds on those three steps.
 :::
 
-Three workstations show browser hijacking symptoms. The team has the morning. The client presentation is in 48 hours. Alex, the agency owner, is hovering near the door looking tense.
+Some workstations show browser hijacking symptoms. The team has the morning. The client presentation is in 48 hours. Alex, the agency owner, is hovering near the door looking tense.
 
 ::: {.callout-tip title="Sly Flourish: two ways to use the clue tables"}
 **Reactive (player-driven):** When a player declares an investigation action that matches a clue below, ask for a d20 roll and read the matching row. The roll determines how much they find and how cleanly.
@@ -178,7 +177,7 @@ A player's wrong hypothesis -- "maybe it is ransomware?" -- is more valuable tha
 | 7-9 ◐ | *"Protector, you find the scheduled task -- 15-minute cadence -- but the executable has renamed itself to something that resembles a Windows system process. You know it is there; you cannot confirm what it is doing."* |
 | 1-6 | *"Protector, the process is masquerading as a system component. Standard signature checks come back clean. A behavior scan is needed, not a file scan."* |
 
-::: {.callout-tip title="[TUTORIAL] The d20 -- the full system"}
+::: {.callout-tip #d20-system title="[TUTORIAL] The d20 -- the full system"}
 When a player attempts something with uncertain outcome -- scanning a system for malware, convincing a skeptical colleague to let them isolate a machine, pulling logs that might have been cleared -- ask for a d20 roll.
 
 **Target numbers:**
@@ -206,7 +205,7 @@ genuinely warrant it.*
 ::: {.callout-warning title="In character -- Alex calls from the doorway"}
 *"I need to know before lunch whether the presentation files are safe. The client is flying in from Copenhagen. If I have to reschedule, it is not just the account -- it is the relationship. Tell me what we are dealing with."*
 
-*She taps her notebook twice on the doorframe before speaking -- a habit the team has learned means she has already made a decision and is waiting for permission to act on it.*
+*She taps her notebook twice before speaking -- a habit the team has learned means she has already made a decision and is waiting for permission to act on it.*
 :::
 
 **Round 1 Decision Point:**
@@ -237,7 +236,7 @@ Alex needs an answer. The team must decide how to respond:
 
 ## Round 2: How Far Did It Go?
 
-The immediate situation is clearer. Now the team needs to understand scope: how many machines are affected, what data was touched, and whether the file server is still clean.
+The source is identified and the decision made. Now the team needs to understand what the malware has been doing since it installed -- and whether it has already reached further than the affected workstations.
 
 ::: {.callout-tip title="[TUTORIAL] Collaboration Bonus -- introduce the first time two players want to work together"}
 When two or more players combine their actions toward the same goal:
@@ -328,7 +327,9 @@ FakeBat is a **Downloader / Trojan** type.
 
 - **Super effective:** Network isolation of infected hosts + full removal of persistence artifacts (scheduled tasks, registry keys) + credential resets for all affected accounts. This combination removes the malware, cuts the C2 connection, and invalidates any harvested credentials.
 - **Not very effective:** Antivirus scan alone. FakeBat uses legitimate-looking scheduled tasks for persistence. An antivirus that catches the initial binary will miss the reinstaller unless the task is also removed.
-- **Normal effectiveness:** Everything else.
+- **Normal effectiveness:** Scheduled task removal + malware scan + credential reset.
+  Removes the installed malware and its main persistence mechanism, but leaves more room
+  for error than a full rebuild. (This is Option B below.)
 :::
 
 **Final Response Decision:**

--- a/im-handbook/resources/im-onboarding/gaboon-grabber/index.qmd
+++ b/im-handbook/resources/im-onboarding/gaboon-grabber/index.qmd
@@ -34,18 +34,16 @@ scenario-variables:
 
 # GaboonGrabber Beginner Scenario: The Fundraiser Email
 
-::: {.scenario-card organization="Clearwater Community Foundation (20-person nonprofit)" stakes="14,000 donor records + Annual fundraiser launch + Regulatory obligations" hook="Tom Reeves, volunteer coordinator, clicked a phishing email disguised as a password reset 18 hours ago. The credential harvester has been running overnight. The fundraiser goes live in 48 hours." pressure="- Annual fundraiser launching in 48 hours -- funds all programmes for the next 12 months  - 14,000 donor records in the database, some with payment details  - Board call scheduled this morning -- Director Priya Chen needs answers before then" malmon="GaboonGrabber" npcs="- Priya Chen (Director): Precise, composed, asks exactly two questions then stops. *'Those are the only two questions that matter to me right now.'*  - Tom Reeves (Volunteer Coordinator): Clicked the link. Embarrassed, not defensive, trails off when speaking. *'I thought I had locked myself out again.'*" secrets="- Phishing email sent from `noreply@donor-portal-secure.net` -- not the foundation's domain  - GaboonGrabber installed 3 minutes after click; has been harvesting credentials for 18 hours  - Harvested data includes Tom's VPN credentials -- attacker can log in remotely right now" villain-plan="- Stage 1: GaboonGrabber installed via phishing lure disguised as a password reset; credentials being harvested [✓]  - Stage 2: Attacker logs in via VPN using Tom's credentials and runs an export query against the 14,000-record donor database" adaptation-notes="- First-session IMs: Follow the tutorial callouts in order. Let Tom's visible embarrassment create natural social dynamics before the team investigates technically.  - Experienced IMs running this as a demo: Skip the tutorial callouts and treat as a standard session.  - The phishing scenario is chosen because credential theft via password reset is the most common real-world entry point players will face." scenario-type="Phishing / Credential Theft" difficulty="Beginner" time-estimate="45-75 minutes"}
+::: {.scenario-card organization="Clearwater Community Foundation (20-person nonprofit)" stakes="14,000 donor records + Annual fundraiser launch + Regulatory obligations" hook="The security monitoring tool flagged unusual activity on Tom Reeves' workstation overnight. Tom is in the room. The fundraiser launches in 48 hours." pressure="- Annual fundraiser launching in 48 hours -- funds all programmes for the next 12 months  - 14,000 donor records in the database, some with payment details  - Board call scheduled this morning -- Director Priya Chen needs answers before then" malmon="GaboonGrabber" npcs="- Priya Chen (Director): Precise, composed, asks exactly two questions then stops. *'Those are the only two questions that matter to me right now.'*  - Tom Reeves (Volunteer Coordinator): Clicked the link. Embarrassed, not defensive, trails off when speaking. *'I thought I had locked myself out again.'*" secrets="- Phishing email sent from `noreply@donor-portal-secure.net` -- not the foundation's domain  - GaboonGrabber installed 3 minutes after click; has been harvesting credentials for 18 hours  - Harvested data includes Tom's VPN credentials -- attacker can log in remotely right now" villain-plan="- Stage 1: GaboonGrabber installed via phishing lure disguised as a password reset; credentials being harvested [✓]  - Stage 2: Attacker logs in via VPN using Tom's credentials and runs an export query against the 14,000-record donor database" adaptation-notes="- First-session IMs: Follow the tutorial callouts in order. Let Tom's visible embarrassment create natural social dynamics before the team investigates technically.  - Experienced IMs running this as a demo: Skip the tutorial callouts and treat as a standard session.  - The phishing scenario is chosen because credential theft via password reset is the most common real-world entry point players will face." scenario-type="Phishing / Credential Theft" difficulty="Beginner" time-estimate="45-75 minutes"}
 :::
 
 ---
 
 ## IM Overview
 
-- **Malmon:** GaboonGrabber
-- **Setting:** Small nonprofit (20 employees), fundraiser campaign launching in 48 hours
+- **Malmon:** [GaboonGrabber](../../malmon-details/gaboon-grabber.html)
 - **Runtime:** 45-75 minutes (Lunch and Learn)
 - **Players:** 4 (pre-generated team included below)
-- **Difficulty:** First session -- no prior experience required
 
 ::: {.callout-important title="First-Order Rules -- the only things that stay constant"}
 M&M has four rules that never change. Everything else is your style.
@@ -54,7 +52,7 @@ M&M has four rules that never change. Everything else is your style.
    results and evolve the threat.
 
 2. **Success Mechanic:** Simple actions succeed automatically. Complex actions: roll d20,
-   5+ easy, 10+ medium, 15+ hard. (See the d20 callout in Round 1.)
+   5+ easy, 10+ medium, 15+ hard. (See the [d20 callout](#d20-system) in Round 1.)
 
 3. **Collaboration:** Players assisting each other: +1 per assisting player (max +3),
    or roll two dice and take the higher.
@@ -79,10 +77,11 @@ The Stage 2 ending -- where the donor database export completes -- is designed t
 **Materials needed:**
 
 - This document (print or screen)
-- 1 (or more) x d20 die (players can share - or they have their own)
-- Role cards for: Detective, Protector, Tracker, Communicator
+- Physical d20 dice -- bring a handful (3-5 recommended); players can share one die but everyone rolling their own is more engaging. Digital dice apps exist as a last resort when no physical dice are available.
+- [Role cards](../../role-cards-reference.html) for: Detective, Protector, Tracker, Communicator
+- [Player tent cards](../../../../players-handbook/resources/player-tent-cards.html) (optional -- printable name placards for the table)
 
-**No other preparation required.** Everything -- clues, NPC lines, decision points, and resolution endings -- is scripted below. Read through once before running. If you have 5 extra minutes, read the Setting the Scene box aloud to yourself.
+**No other preparation required.** Everything -- clues, NPC lines, decision points, and resolution endings -- is scripted below. Read through once before running. If you have 5 extra minutes, read the [Setting the Scene](#setting-the-scene) section aloud to yourself.
 
 ::: {.callout-tip title="You cannot break this scenario"}
 Every path through this scenario leads somewhere useful. If Stage 2 triggers, the debrief
@@ -113,19 +112,19 @@ Hand out role cards and ask: "Which of these sounds most like how you would appr
 When the script addresses a clue to a role -- "Tracker, the VPN log shows..." -- use the player's actual name instead of the role label. Players are themselves in this scenario.
 :::
 
-- **Detective** -- "You always ask who had access and when. Your job is to trace what happened."
+- **[Detective](../../role-cards-reference.html#detective-cyber-sleuth)** -- "You always ask who had access and when. Your job is to trace what happened."
   - *Situational anchor:* You volunteered to help the foundation after last year's fundraiser. This is the first time you have been called into an actual incident.
   - *Play as:* you ask one more question even when the team is ready to act.
 
-- **Protector** -- "Your instinct is to isolate first, ask questions second. You keep the threat from spreading."
+- **[Protector](../../role-cards-reference.html#protector-digital-guardian)** -- "Your instinct is to isolate first, ask questions second. You keep the threat from spreading."
   - *Situational anchor:* You set up the VPN access for volunteer coordinators like Tom. You want to know if the architecture held.
   - *Play as:* you state the action you want to take, then immediately ask who disagrees.
 
-- **Tracker** -- "You follow the data trail. You want logs and timestamps before anyone acts."
+- **[Tracker](../../role-cards-reference.html#tracker-network-analyst)** -- "You follow the data trail. You want logs and timestamps before anyone acts."
   - *Situational anchor:* You are the one who flagged the security alert this morning. You forwarded it to Priya at 8:02am.
   - *Play as:* you quote a specific number from the evidence before making any recommendation.
 
-- **Communicator** -- "You keep stakeholders calm and the team aligned. You decide what gets communicated and when."
+- **[Communicator](../../role-cards-reference.html#communicator-stakeholder-liaison)** -- "You keep stakeholders calm and the team aligned. You decide what gets communicated and when."
   - *Situational anchor:* You manage the donor relationships. If 14,000 records are at risk, you are the one who has to look those donors in the eye.
   - *Play as:* you repeat back what you heard before responding, especially when the news is bad.
 
@@ -241,7 +240,7 @@ A player's wrong hypothesis -- "maybe it is ransomware?" -- is more valuable tha
 | 1-6 | *"Protector, the process detects your investigation and terminates. The malware is gone -- and so is the forensic evidence. You know it was there; you cannot confirm what it took."* |
 :::
 
-::: {.callout-tip title="[TUTORIAL] The d20 -- the full system"}
+::: {.callout-tip #d20-system title="[TUTORIAL] The d20 -- the full system"}
 When a player attempts something with uncertain outcome -- convincing Tom to share his credentials for investigation, isolating a live machine without crashing an open report, pulling VPN logs for the past 24 hours -- ask for a d20 roll.
 
 **Target numbers:**

--- a/im-handbook/resources/practical-tools/im-quick-start-guide.qmd
+++ b/im-handbook/resources/practical-tools/im-quick-start-guide.qmd
@@ -22,13 +22,84 @@ description: "Essential one-page reference for Incident Masters running Malware 
 *Everything else in this guide—modifiers, specific types, and complex mechanics—is optional strategy. Use them when you're ready.*
 :::
 
+## Your First Decision: Which Path?
+
+Three paths into M&M. Pick the one that matches where you are right now.
+
+| Path | When | Prep time | What you need |
+|------|------|-----------|---------------|
+| **Path 1: Zero-prep session** | Your very first session | 15-20 min read-through | Onboarding scenario doc + a d20 |
+| **Path 2: Pick your own scenario** | After your first session | ~30 min | Scenario card + New IM Prep workflow |
+| **Path 3: Build from scratch** | Experienced IMs only | Open-ended | Comfortable with Paths 1 and 2 first |
+
+**Start with Path 1.** The IM Onboarding Scenarios are fully scripted -- every clue, NPC line, and resolution ending is written out. You read through once, bring a d20, and run it. No improvisation required.
+
+---
+
+## Path 1: Zero-Prep Session (Start Here)
+
+Two onboarding scenarios are available. Either works as a first session:
+
+- [FakeBat: Friday Deadline](../im-onboarding/fakebat/index.html) -- small creative agency, 12 employees, client presentation deadline
+- [GaboonGrabber: The Fundraiser Email](../im-onboarding/gaboon-grabber/index.html) -- small nonprofit, 20 employees, fundraiser launch in 48 hours
+
+**Absolute requirements (session cannot run without these):**
+
+- The onboarding scenario doc (screen or printout)
+- At least one physical d20 die -- a handful is better (3-5 recommended; players sharing one die works but everyone rolling their own is more engaging)
+- 3-6 players in the room
+
+The scripts are written for 4 players using four pre-generated roles (Detective, Protector, Tracker, Communicator). 
+**Fewer than 4?** Let each person take two roles, or leave a role unassigned and spread its responsibilities across the group -- the scenario still runs cleanly.  
+**More than 4?** Pair two players on one role; they discuss and agree before acting. Up to 6 works well. Beyond that, some players will feel like spectators.  
+
+**Nice-to-have (add these when you're ready, not required for your first session):**
+
+- Read through the scenario once beforehand (15-20 min -- strongly recommended even though it is not required)
+- [Printed role cards](../../../players-handbook/resources/role-cards.html) or [tent cards](../../../players-handbook/resources/player-tent-cards.html) -- players remember their role without having to ask
+- Printed Handout A and Handout B (each zero prep scenario has them) -- physical artifacts increase immersion
+- Evidence and decision slips cut beforehand -- optional, adds physical interaction
+- Timer or visible clock
+
+::: {.callout-tip title="Optional reading before your first session"}
+The onboarding scenario has everything you need. But if you have 20 minutes to spare beforehand, the [Facilitation Philosophy](../../chapters/00-facilitation-philosophy.html) chapter explains the question-driven approach at the heart of M&M. The [Sly Flourish Principles](../../chapters/01-sly-flourish-principles.html) chapter covers concepts like "yes, and" improv technique and the lazy IM philosophy -- both of which you will feel working as you run the scenario even if you have never heard the terms. Neither is required for Path 1.
+:::
+
+**Save these for Path 2:**
+
+- Scenario selection decisions
+- NPC voice preparation
+- Complexity dialing
+- d20 modifier tables
+- Session prep worksheet
+
+---
+
+## For Experienced TTRPG GMs and DMs
+
+If you have run tabletop RPG sessions before, M&M will feel immediately familiar -- and a few things will feel unexpectedly different. Here is what to expect:
+
+- **The world has a fixed answer.** The malmon family, its attack vector, and its behavior are defined by the scenario card. You cannot decide the villain is "actually something else" mid-session. The investigation leads somewhere real -- your job is to let players find it.
+- **Characters are IR roles, not adventure heroes.** Players use role cards (Detective, Protector, Tracker, Communicator) that work like character sheets -- modifiers, role-specific abilities, and guidance for how to play the role. Players can inhabit a role that mirrors their real job or take on something completely different; both work. What is different from TTRPG is that roles are grounded in incident response functions, not fantasy archetypes, and there is no long-term character arc or growth across sessions. Each session, each player picks up a role and steps into a professional crisis.
+- **Failure is often the best outcome.** In TTRPG you typically want the party to succeed and the story to resolve satisfyingly. In M&M, a Stage 2 trigger firing -- the fundraiser donor records accessed, the presentation files corrupted -- often produces a better session than a clean win. Failure creates richer debrief questions and deeper learning. Storytelling, fun, and immersion are fully part of the experience; what shifts is that you do not need to protect players from consequences. Let the scenario play out honestly and harvest the learning from wherever it lands.
+- **The enemy is the scenario, not you.** In TTRPG the GM sometimes wants the party to struggle. In M&M you want players to succeed -- you are a collaborator facilitating discovery, not an adversary providing challenge.
+- **"Yes, and" has a technical floor.** You can absolutely improvise consequences, escalations, and NPC reactions. But if a player proposes something technically implausible (hacking back into the C2 server, calling the FBI and having them respond in 10 minutes), adjudicate against real-world plausibility, not just narrative interest.
+- **The dice are rare.** TTRPG sessions roll constantly. In M&M, simple actions auto-succeed. The d20 appears only when an action is genuinely uncertain with meaningful stakes. Do not call for dice when the outcome is obvious.
+- **NPC depth is a tool, not a requirement.** NPCs can be purely functional (conveying pressure, delivering information) or richly dramatic -- the flustered IT director whose team is about to take the blame, the CEO who goes from demanding to quietly terrified when she understands the scope. Lean into character moments when they serve immersion. The difference from TTRPG is that NPCs do not have their own storylines that compete with the investigation. Their drama serves the scenario, not the other way around.
+- **Players already know more than you.** In TTRPG, the GM knows the lore and adjudicates it. In M&M, a player who works in IT security knows more than you about what the Detective's action would realistically achieve. Trust that. Your questions draw out their expertise -- they do not test yours.
+- **Progression is real-world, not in-fiction.** Players do accumulate things across sessions -- badges for skills demonstrated, MalDex entries for malmons encountered, an evolving record of what they have learned. What does not carry over is in-fiction power: there is no character becoming stronger in the story world, no equipment loadout, no narrative "last time we faced the goblin king..." Each session is a self-contained crisis. The growth happens in the player, not the character.
+
+---
+
 ## How to Use This Guide
 
-This guide contains everything you might need to enrich your sessions, organized into three tiers. **These are second-order rules:** optional strategic, technical, and facilitation details that build on the [First-Order Rules](#first-order-rules-the-minimum-you-need-to-play) above.
+**This section covers Paths 2 and 3 -- scenario cards and beyond.** If you are running your first session with an onboarding scenario (Path 1), skip this section entirely and go directly to one of the zero prep scenarios.
 
-**🔴 Tier 1: Essential** - Read before your first session
+This guide contains everything you might need to enrich your scenario-card sessions, organized into three tiers. **These are second-order rules:** optional strategic, technical, and facilitation details that build on the [First-Order Rules](#first-order-rules-the-minimum-you-need-to-play) above.
 
-- [Your First Session: 4 Steps](#your-first-session-4-steps)
+**🔴 Tier 1: Path 2 essentials** - Read when you are ready to pick your own scenario (after your first zero-prep session)
+
+- [Path 2: Picking Your Own Scenario](#path-2-picking-your-own-scenario)
 - [Choosing Your Malmon](#choosing-your-malmon)
 - [Choosing Your Scenario](#choosing-your-scenario)
 - [Dialing Complexity](#dialing-complexity-to-your-comfort-level)
@@ -58,17 +129,13 @@ This guide contains everything you might need to enrich your sessions, organized
 
 - [Using Scenario Slides](#using-scenario-slides)
 
-**New facilitators:** Read Tier 1 sections in order, then run your first session. Come back to Tier 2 when you need specific information.
+**First session?** Start with [Path 1](#path-1-zero-prep-session-start-here) above -- no prep needed. Come back to the Tier 1 sections below when you are ready to pick your own scenario.
 
 ---
 
-## Your First Session: 4 Steps
+## Path 2: Picking Your Own Scenario
 
-::: {.callout-note}
-**Prefer zero prep?** [FakeBat: Friday Deadline](../im-onboarding/fakebat/index.html) or [GaboonGrabber: The Fundraiser Email](../im-onboarding/gaboon-grabber/index.html) -- fully scripted, mechanics introduced one at a time, no improvisation required (45-75 min).
-:::
-
-**Picking your own scenario? Here's your path:**
+Ready to move beyond the onboarding scenarios? Here is your four-step path:
 
 1. **Pick a malmon** - [Choose based on what you want to teach](#choosing-your-malmon)
 2. **Pick a scenario** - [Match your audience's industry](#choosing-your-scenario)
@@ -77,13 +144,15 @@ This guide contains everything you might need to enrich your sessions, organized
 
 Then read the other 🔴 Tier 1 sections and fill in your [Session Prep Worksheet](preparation-templates/im-session-prep-worksheet.html).
 
+**Path 3 -- building from scratch** is the natural next step once you are comfortable with scenario cards. That is covered separately when you are ready.
+
 Everything else in this guide is reference material - come back to it when you need specific information.
 
 ---
 
 ## Choosing Your Malmon
 
-:::{.callout-note title="🔴 Tier 1: Essential - Start with the Threat Type"}
+:::{.callout-note title="🔴 Path 2 Tier 1: Start with the Threat Type"}
 Each malmon teaches different incident response concepts. Pick based on what you want your players to learn.
 :::
 
@@ -106,11 +175,11 @@ Each malmon teaches different incident response concepts. Pick based on what you
 
 ## Choosing Your Scenario
 
-:::{.callout-note title="🔴 Tier 1: Essential - Match Your Audience"}
+:::{.callout-note title="🔴 Path 2 Tier 1: Match Your Audience"}
 Each malmon has multiple scenario variants set in different industries. Pick one that resonates with your players.
 :::
 
-If this is your very first session, a Beginner Scenario removes scenario selection entirely -- see the callout above.
+If this is your very first session, use Path 1 instead -- the onboarding scenarios remove all selection decisions.
 
 **General guidance:**
 
@@ -124,7 +193,7 @@ If this is your very first session, a Beginner Scenario removes scenario selecti
 
 ## Dialing Complexity to Your Comfort Level
 
-:::{.callout-note title="🔴 Tier 1: Essential - You Control the Difficulty"}
+:::{.callout-note title="🔴 Path 2 Tier 1: You Control the Difficulty"}
 Scenario cards show everything available - the complexity ceiling. You decide how much to use.
 :::
 
@@ -152,7 +221,7 @@ Scenario cards show everything available - the complexity ceiling. You decide ho
 
 ## Choosing Your Session Format
 
-:::{.callout-note title="🔴 Tier 1: Essential - Format Shapes Your Role"}
+:::{.callout-note title="🔴 Path 2 Tier 1: Format Shapes Your Role"}
 Quick Demo and Full Game require different facilitation styles. Neither is "easier" - they're different.
 :::
 
@@ -196,7 +265,7 @@ But:
 
 ## Your First Prep: From Scenario Card to Session Notes
 
-:::{.callout-note title="🔴 Tier 1: Essential - Do This Before Your First Session"}
+:::{.callout-note title="🔴 Path 2 Tier 1: Do This Before Picking Your Own Scenario"}
 Once you've read the Tier 1 essentials, fill in your [IM Session Prep Worksheet](preparation-templates/im-session-prep-worksheet.html).
 Here's exactly how to extract what you need from any scenario card.
 :::
@@ -404,7 +473,7 @@ This section bridges that gap with a concrete 5-step workflow. We'll use GaboonG
 
 ## Core Facilitation Philosophy
 
-:::{.callout-note title="🔴 Tier 1: Essential - Read Before Your First Session"}
+:::{.callout-note title="🔴 Path 2 Tier 1: Read Before Picking Your Own Scenario"}
 This section covers the foundational mindset for facilitating M&M sessions.
 :::
 
@@ -434,7 +503,7 @@ This section covers the foundational mindset for facilitating M&M sessions.
 
 ## Storytelling with Scenario Cards
 
-:::{.callout-note title="🔴 Tier 1: Essential - Read Before Your First Session"}
+:::{.callout-note title="🔴 Path 2 Tier 1: Read Before Picking Your Own Scenario"}
 This section teaches you how to bring scenario cards to life through simple storytelling techniques.
 :::
 
@@ -524,7 +593,7 @@ That's it. The rest of this section explains techniques for when you're ready to
 
 ## How to Start Your Session
 
-:::{.callout-note title="🔴 Tier 1: Essential - Read Before Your First Session"}
+:::{.callout-note title="🔴 Path 2 Tier 1: Read Before Picking Your Own Scenario"}
 This section covers the critical first 15 minutes: getting players settled, roles assigned, and smoothly transitioning into the scenario.
 :::
 
@@ -666,7 +735,7 @@ After introductions, seamlessly deliver your scenario hook (from "Storytelling w
 
 ## Session Structure at a Glance
 
-:::{.callout-note title="🔴 Tier 1: Essential - Read Before Your First Session"}
+:::{.callout-note title="🔴 Path 2 Tier 1: Read Before Picking Your Own Scenario"}
 This section explains the different session formats and helps you choose which one to run.
 :::
 
@@ -791,7 +860,7 @@ All four session formats now have comprehensive prep checklists. Choose your for
 
 ## The Core Game Loop
 
-:::{.callout-note title="🔴 Tier 1: Essential - Read Before Your First Session"}
+:::{.callout-note title="🔴 Path 2 Tier 1: Read Before Picking Your Own Scenario"}
 This section describes the fundamental 4-step pattern that every M&M round follows.
 :::
 
@@ -819,7 +888,7 @@ This section describes the fundamental 4-step pattern that every M&M round follo
 
 ## Essential IM Questions
 
-:::{.callout-note title="🔴 Tier 1: Essential - Read Before Your First Session"}
+:::{.callout-note title="🔴 Path 2 Tier 1: Read Before Picking Your Own Scenario"}
 This section provides ready-to-use questions that facilitate discovery without lecturing.
 :::
 
@@ -851,7 +920,7 @@ This section provides ready-to-use questions that facilitate discovery without l
 
 ## Dice Mechanics Quick Reference
 
-:::{.callout-note title="🔴 Tier 1: Essential - Read Before Your First Session"}
+:::{.callout-note title="🔴 Path 2 Tier 1: Read Before Picking Your Own Scenario"}
 This section provides the core game mechanics you need to adjudicate player actions.
 :::
 

--- a/im-handbook/resources/practical-tools/preparation-templates/new-im-prep.qmd
+++ b/im-handbook/resources/practical-tools/preparation-templates/new-im-prep.qmd
@@ -13,7 +13,7 @@ Beginner Scenarios require no prep -- everything is scripted. This 30-minute wor
 #### Essential Materials Checklist
 - [ ] Malmon cards for chosen scenario (plus 2-3 backups)
 - [ ] [Role tent cards](../../../../players-handbook/resources/player-tent-cards.html) -- one per player seat, print and fold beforehand
-- [ ] Physical d20 dice (2-3 minimum) - apps often fail
+- [ ] Physical d20 dice -- bring a handful (3-5 recommended); apps are a last resort, not the default
 - [ ] [Network Security Status tracker](../session-materials/network-security-status-tracker.html) (paper backup)
 - [ ] [Evidence & decision slips](../session-materials/evidence-cards.html) -- cut beforehand, ~8 per session
 - [ ] Blank paper for participant notes and diagrams
@@ -228,7 +228,7 @@ Know your options when things go wrong:
 
 - [ ] Paper alternatives for all digital tools ready
 - [ ] Manual Network Security Status tracking method
-- [ ] Physical dice available as backup
+- [ ] Digital dice apps available as backup (physical dice are preferred)
 - [ ] Continue-regardless mindset
 
 **Participant Issues:**

--- a/index.qmd
+++ b/index.qmd
@@ -28,7 +28,7 @@ body-attributes:
 New here? Pick the path that fits you—these guides stand on their own even if the modal isn’t shown.
 
 - **Players:** [Players Quick Start Guide](players-handbook/resources/players-quick-start.html) — 5–10 minute primer with role cards and quick reference  
-- **Facilitators:** [IM Quick Start Guide](im-handbook/resources/practical-tools/im-quick-start-guide.html) — 20-minute essentials plus a Quick Demo template using a starter scenario
+- **Facilitators:** [IM Quick Start Guide](im-handbook/resources/practical-tools/im-quick-start-guide.html) — Get started right away using a zero-prep starter scenario
 
 ## Overview
 

--- a/players-handbook/index.qmd
+++ b/players-handbook/index.qmd
@@ -49,7 +49,7 @@ Whether you're a seasoned security professional or curious newcomer, you'll find
 ### If You're an Experienced Player  
 - Jump to **[The Containment System](../players-handbook/chapters/07-containment-system.html)** to see how your skills translate to gameplay
 - Explore **[Competitive Elements](../players-handbook/chapters/11-competitive-elements.html)** for advanced challenges
-- Check **[Maldex Collection](../players-handbook/chapters/10-maldex-collection.html)** for the community knowledge-building aspects
+- Check **[MalDex Collection](../players-handbook/chapters/10-maldex-collection.html)** for the community knowledge-building aspects
 - Use **[Training and Progression](../players-handbook/chapters/08-training-progression.html)** to track your growing expertise
 
 ### If You're Looking for Quick Reference

--- a/players-handbook/resources/player-tent-cards.qmd
+++ b/players-handbook/resources/player-tent-cards.qmd
@@ -11,10 +11,10 @@ Place a tent card at each player's seat so everyone can see roles at a glance --
 
 - Set your printer to **A4 landscape** (the page style forces this automatically)
 - Print all 3 sheets -- each sheet has 2 roles
-- Cut each sheet in half along the fold line
-- Fold so the colored side faces the table
+- Cut each sheet in half along the **vertical** dashed line between the two role cards
+- Fold each card backward along the horizontal dotted line -- the colored role name is on top and faces outward; the modifier list faces the player
 
-<div style="margin: 1rem 0;">
+<div class="print-button-bar" style="margin: 1rem 0;">
   <button onclick="window.print()" style="background:#0033FF; color:white; border:none; padding:0.5rem 1.5rem; font-family:monospace; font-size:1rem; cursor:pointer; border-radius:4px;">Print Tent Cards</button>
 </div>
 
@@ -118,55 +118,72 @@ Place a tent card at each player's seat so everyone can see roles at a glance --
 @media print {
   .print-button-bar { display: none !important; }
 
+  /* Issue 1: Intro stays on page 1 -- each sheet starts on its own page */
   .tent-sheet {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 0;
     margin: 0;
     border: none;
-    page-break-after: always;
+    break-before: page;
+    page-break-before: always;
     break-after: page;
+    page-break-after: always;
     height: 190mm; /* A4 landscape with 10mm margins each side */
   }
 
   /* Last sheet -- no trailing page break */
   .tent-sheet:last-child {
-    page-break-after: avoid;
     break-after: avoid;
+    page-break-after: avoid;
   }
 
+  /* Issue 2: Visible cut line between the two cards on each sheet */
+  /* Reorder sections for correct folding: colored side on top, modifiers below fold line */
+  /* When folded, colored side faces outward; modifier list faces the player */
   .tent-card {
     border: none;
-    border-right: 1px dashed #bbb;
+    border-right: 2px dashed #666;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
   }
   .tent-card:last-child { border-right: none; }
 
-  .tent-inside {
-    padding: 8mm;
-    background: white;
-    height: 80mm;
+  /* Issues 3 & 6: Equal fixed heights -- all cards same size, fold line exactly centred */
+  /* 92mm + 6mm fold + 92mm = 190mm total (A4 landscape minus margins) */
+  .tent-outside {
+    order: 1;
+    height: 92mm;
     box-sizing: border-box;
+    padding: 8mm;
+    transform: rotate(180deg);
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
   }
-  .tent-inside h3 { font-size: 10pt; margin-bottom: 4px; }
-  .tent-inside .modifier { font-size: 8.5pt; margin: 3px 0; }
-  .tent-inside .archetype { font-size: 7.5pt; }
 
   .fold-line {
+    order: 2;
     height: 6mm;
     font-size: 7pt;
     line-height: 6mm;
     border-top: 2px dashed #aaa;
     border-bottom: 2px dashed #aaa;
-    page-break-inside: avoid;
     break-inside: avoid;
+    page-break-inside: avoid;
   }
 
-  .tent-outside {
-    height: 104mm;
-    box-sizing: border-box;
+  .tent-inside {
+    order: 3;
     padding: 8mm;
+    background: white;
+    height: 92mm;
+    box-sizing: border-box;
+    overflow: hidden;
   }
+  .tent-inside h3 { font-size: 10pt; margin-bottom: 4px; }
+  .tent-inside .modifier { font-size: 8.5pt; margin: 3px 0; }
+  .tent-inside .archetype { font-size: 7.5pt; }
   .tent-outside .role-emoji { font-size: 28pt; }
   .tent-outside .role-name { font-size: 16pt; }
   .tent-outside .role-subtitle { font-size: 9pt; }


### PR DESCRIPTION
## Summary

- **Beginner scenarios (FakeBat + GaboonGrabber):** applied Johan Sydseter's feedback -- hook text made symptom-only, in-text anchor links added, malmon/role card links wired up, IM Overview stripped of redundant fields, FakeBat Round 2 intro corrected, Round 3 Type Effectiveness expanded
- **Tent card print CSS:** reordered sections so colored role name prints on top (folds correctly), equal heights for all cards, page breaks so intro stays on page 1, background colors forced to print, cut line made visible, print button class fixed
- **IM Quick Start Guide:** added Path 1/2/3 decision table with zero-prep onboarding scenario links

## Test plan

- [ ] Open both beginner scenario pages and verify all anchor links resolve
- [ ] Verify malmon card, role card, and tent card links work
- [ ] Open tent cards page, print preview (Ctrl+P) -- colored side should be on top, heights equal, intro on page 1
- [ ] Confirm background colors print in the tent card colored sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)