### PR TITLE
fix: add event-type filter to Discord deploy notifications

### DIFF
--- a/dev/workspace/CLAUDE.md
+++ b/dev/workspace/CLAUDE.md
@@ -22,71 +22,44 @@ Each Chat History file has a max 5 line summary near the top of the file, and a 
     "The summary of the conversation is here"
     <<<
 
-# Feature: Large Group Session Formats (12-15+ Players)
+# Fix: Discord Bot Workflow Notification Filtering
 
-**Branch:** `feature/large-group-session-formats`
-**Started:** `2026-03-12`
-**Issue:** #174
+**Branch:** `fix/discord-workflow-filter`
+**Started:** `2026-04-06`
+**Issue:** Operational fix (no GitHub issue)
 **Status:**
 
-- [ ] In Progress
+- [x] In Progress
 - [ ] Discard (workspace and branch abandoned)
-- [x] Complete (ready to merge)
+- [ ] Complete (ready to merge)
 
 ## Purpose
 
-Add comprehensive support for running M&M with large groups (12-15+ players). Standard 4-6 player format doesn't suit organizational training, team-building workshops, and enterprise IR team exercises.
+The Discord bot posts "Deploy Succeeded" messages for ALL completed GitHub Actions workflows on tracked branches, including non-deploy workflows like "Validate Issue Project Fields". This creates noisy spam in the Discord channel (5+ duplicate messages every time issues are edited/labeled).
 
-Large groups need concrete artifacts for parallel independent analysis -- this enables teams to work without constant IM attention. This is a two-tier implementation: Tier 1 is documentation (Chapter 11, Quick Start Guide, new Prep Worksheet); Tier 2 is content (organizational context enhancements with tiered artifact sets for Phase 1 scenarios).
+Two prior fix attempts exist on main but the deployed bot still exhibits the problem:
+- `b6fb406` (March 8) -- Added tracked_workflows allowlist with truthy guard (bypassed when list empty)
+- `7370d06` (March 23) -- Made filter fail-closed (removed truthy guard)
 
-**Target Audience:** Experienced IMs (3-5+ standard sessions) running large workshops
+Root cause hypothesis: deployed Docker image may not have picked up latest code, OR settings.yml on server lacks `tracked_workflows` key causing empty-list default.
 
 ## Scope
 
-### Tier 1 -- Documentation (this branch, implement first)
+- Add defense-in-depth: event-type filtering (only `push`/`workflow_dispatch` trigger deploy notifications)
+- Add startup logging of tracked workflows configuration for deployment debugging
+- Ensure filter is robust against missing/empty config
+- Add tests for new filtering logic
 
-- `im-handbook/chapters/11-session-management.qmd` -- Add "Scaling to Large Groups" section with beginner IM warning
-- `im-handbook/resources/practical-tools/im-quick-start-guide.qmd` -- Add brief reference callout with beginner IM warning
-- `im-handbook/resources/practical-tools/preparation-templates/large-group-prep-worksheet.qmd` -- NEW FILE (copy `im-session-prep-worksheet.qmd` as template)
+## Workspace Configuration
 
-### Tier 2 -- Phase 1 Content (4 scenarios)
+### Merge Strategy
+- [ ] Squash merge
+- [x] Rebase merge
+- [ ] Merge commit
 
-- `im-handbook/resources/scenario-cards/lockbit/hospital-emergency/`
-- `im-handbook/resources/scenario-cards/noodle-rat/biotech-research/`
-- `im-handbook/resources/scenario-cards/wannacry/hospital-emergency/`
-- `im-handbook/resources/scenario-cards/stuxnet/manufacturing-deadline/`
-
-## Task Checklist
-
-**Tier 1 -- Documentation**
-
-- [x] Read `11-session-management.qmd` -- find "Managing Different Group Types" and "Recognizing Natural Endings" sections
-- [x] Add "Scaling to Large Groups" section to Chapter 11
-- [x] Read `im-quick-start-guide.qmd` -- find "Session Structure at a Glance" section
-- [x] Add large group callout to Quick Start Guide
-- [x] Read `im-session-prep-worksheet.qmd` -- use as template base
-- [x] Create `large-group-prep-worksheet.qmd`
-- [x] Add new worksheet to `im-handbook/_quarto.yml` under preparation-templates
-
-**Tier 2 -- Phase 1 Artifacts (post Tier 1)**
-
-- [x] LockBit hospital-emergency -- 21 artifact set (Alpha/Bravo/Charlie x 7)
-- [x] Noodle RAT biotech-research -- 21 artifact set
-- [x] WannaCry hospital-emergency -- 21 artifact set
-- [x] Stuxnet manufacturing-deadline -- 21 artifact set
-
-**Post-completion**
-
-- [x] Add large group artifact links from all 4 scenario index.qmd files to organizational-context.html
-- [x] Fix Quarto ::: warnings (blank line rule) across all 4 scenario files
-
-## Key Design Decisions
-
-- Five formats: Multi-Team Coordination, Shift Handover, Specialist Bench, Consensus Under Pressure, Fishbowl Rotation
-- Tiered artifact system: Initial Indicators (R1) / Deep Analysis (R2-3) / Developments (R4-5)
-- Team lens mapping: Alpha (Forensics), Bravo (Network/Infra), Charlie (Business Impact)
-- IC rotation principle: IC should NOT be someone who leads incidents in real life
-- Beginner IM warning required in ALL large group documentation
+### Post-Merge
+- [x] Delete branch after merge
+- [ ] Archive workspace upon merge
 
 ## Path Convention
 

--- a/discord-bot/bots/repo_notifications.py
+++ b/discord-bot/bots/repo_notifications.py
@@ -36,6 +36,9 @@ class RepoNotificationsBot:
         self.workflow_runs_per_branch = int(config.get("notifications.workflow_runs_per_branch", 50))
         self.tracked_branches = config.get("notifications.deploy.tracked_branches", ["testing", "main"])
         self.tracked_workflows = config.get("notifications.deploy.tracked_workflows", [])
+        self.allowed_deploy_events = config.get(
+            "notifications.deploy.allowed_events", ["push", "workflow_dispatch"]
+        )
         self.workflow_bootstrap_mode = str(
             config.get("notifications.workflow.bootstrap_mode", "from_now")
         ).lower()
@@ -71,7 +74,9 @@ class RepoNotificationsBot:
             f"poll={self.poll_interval_minutes}m, channel={self.channel_id}, "
             f"workflow_bootstrap={self.workflow_bootstrap_mode}, "
             f"history_dedupe={self.workflow_history_dedupe_enabled}, "
-            f"testing_ai_summary={self.testing_ai_summary_enabled})"
+            f"testing_ai_summary={self.testing_ai_summary_enabled}, "
+            f"tracked_workflows={self.tracked_workflows}, "
+            f"allowed_deploy_events={self.allowed_deploy_events})"
         )
 
     async def handle_issues_webhook(self, payload: dict, action: str) -> None:
@@ -316,6 +321,18 @@ class RepoNotificationsBot:
             )
             return False
 
+        run_event = run.get("event", "")
+        if self.allowed_deploy_events and run_event not in self.allowed_deploy_events:
+            logger.debug(
+                "Skipping workflow run: event type not in allowed_deploy_events "
+                "event=%s name=%s branch=%s run_id=%s",
+                run_event,
+                workflow_name,
+                branch,
+                run.get("id"),
+            )
+            return False
+
         if run.get("status") != "completed" or run.get("conclusion") != "success":
             return False
 
@@ -401,12 +418,14 @@ class RepoNotificationsBot:
             return False
 
         logger.info(
-            "Repo notification sent [workflow_run] source=%s branch=%s run_id=%s attempt=%s workflow=%s event_key=%s",
+            "Repo notification sent [workflow_run] source=%s branch=%s run_id=%s "
+            "attempt=%s workflow=%s event=%s event_key=%s",
             source,
             branch,
             run_id,
             run_attempt,
             run.get("name", "Unnamed workflow"),
+            run.get("event", "unknown"),
             event_key,
         )
         return True

--- a/discord-bot/config/settings.yml
+++ b/discord-bot/config/settings.yml
@@ -321,6 +321,9 @@ notifications:
     tracked_workflows:
       - "Build and Deploy to GitHub Pages"
       - "Build and Deploy Testing Branch to Preview Subdirectory"
+    allowed_events:
+      - "push"
+      - "workflow_dispatch"
     # Message customization for successful testing deploy notifications.
     # Available placeholders: {workflow_name}
     testing_message_title: "🧪 New Testing Build Available"

--- a/discord-bot/tests/bots/test_repo_notifications.py
+++ b/discord-bot/tests/bots/test_repo_notifications.py
@@ -16,12 +16,13 @@ def _async_iter(items):
     return _gen()
 
 
-def _workflow_run(run_id: int, branch: str = "testing", updated_at: str = None) -> dict:
+def _workflow_run(run_id: int, branch: str = "testing", updated_at: str = None, event: str = "push") -> dict:
     if updated_at is None:
         updated_at = datetime.now(timezone.utc).isoformat()
     return {
         "id": run_id,
         "name": "Build and Deploy Testing Branch to Preview Subdirectory",
+        "event": event,
         "status": "completed",
         "conclusion": "success",
         "head_branch": branch,
@@ -182,6 +183,47 @@ class TestRepoNotificationsBot:
         posted = await repo_bot._process_workflow_run(run=_workflow_run(66666), source="poll")
         assert posted is False
         mock_channel.send.assert_not_called()
+
+    async def test_workflow_run_issues_event_is_filtered(self, repo_bot):
+        """Workflow triggered by issues event must not post even if name is tracked."""
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock()
+        mock_channel.history = MagicMock(return_value=_async_iter([]))
+        repo_bot.bot.get_channel.return_value = mock_channel
+
+        run = _workflow_run(77777, event="issues")
+        posted = await repo_bot._process_workflow_run(run=run, source="webhook")
+        assert posted is False
+        mock_channel.send.assert_not_called()
+
+    async def test_workflow_run_push_event_is_allowed(self, repo_bot):
+        """Workflow triggered by push event should post successfully."""
+        repo_bot.workflow_history_dedupe_enabled = False
+
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock(return_value=MagicMock(id=116))
+        mock_channel.history = MagicMock(return_value=_async_iter([]))
+        repo_bot.bot.get_channel.return_value = mock_channel
+
+        run = _workflow_run(88888, event="push")
+        posted = await repo_bot._process_workflow_run(run=run, source="webhook")
+        assert posted is True
+        mock_channel.send.assert_called_once()
+
+    async def test_workflow_run_empty_allowed_events_disables_filter(self, repo_bot):
+        """Empty allowed_deploy_events should disable event filter (fail-open)."""
+        repo_bot.allowed_deploy_events = []
+        repo_bot.workflow_history_dedupe_enabled = False
+
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock(return_value=MagicMock(id=117))
+        mock_channel.history = MagicMock(return_value=_async_iter([]))
+        repo_bot.bot.get_channel.return_value = mock_channel
+
+        run = _workflow_run(99998, event="issues")
+        posted = await repo_bot._process_workflow_run(run=run, source="webhook")
+        assert posted is True
+        mock_channel.send.assert_called_once()
 
     def test_deploy_footer_includes_source_marker_when_enabled(self, repo_bot):
         """Deploy footer should include optional source marker for diagnostics."""

--- a/discord-bot/tests/conftest.py
+++ b/discord-bot/tests/conftest.py
@@ -31,7 +31,7 @@ def temp_db_path():
 @pytest.fixture
 async def test_db(temp_db_path):
     """Create test database instance."""
-    db = Database(temp_db_path)
+    db = Database(Path(temp_db_path))
     await db.initialize()
 
     yield db
@@ -86,7 +86,8 @@ def mock_config():
                 "tracked_workflows": [
                     "Build and Deploy to GitHub Pages",
                     "Build and Deploy Testing Branch to Preview Subdirectory",
-                ]
+                ],
+                "allowed_events": ["push", "workflow_dispatch"],
             }
         },
         "database": {


### PR DESCRIPTION
## Summary

The Discord bot posts "Deploy Succeeded" messages for non-deploy workflows like "Validate Issue Project Fields", creating noisy spam (5+ messages per issue edit batch). Two prior fixes (workflow name allowlist) exist on main but the deployed bot still leaks.

This adds a second, independent event-type filter as defense-in-depth: only `push` and `workflow_dispatch` events trigger deploy notifications. The "Validate Issue Project Fields" workflow triggers on `issues` events, so it is independently blocked regardless of the name filter.

## What Changed

- Load `allowed_deploy_events` config with sensible defaults (`push`, `workflow_dispatch`)
- Log `tracked_workflows` and `allowed_deploy_events` at startup for deployment debugging
- Add event-type filter in `_process_workflow_run()` after the existing name check
- Include `event` in the "sent" log line for observability
- Add `allowed_events` to `settings.yml`
- Fix pre-existing `Path` vs `str` bug in `test_db` fixture
- Add 3 new tests for event-type filtering (all passing)

## Test plan

- [x] `test_workflow_run_issues_event_is_filtered` -- tracked name + issues event => blocked
- [x] `test_workflow_run_push_event_is_allowed` -- tracked name + push event => posted
- [x] `test_workflow_run_empty_allowed_events_disables_filter` -- empty list => fail-open
- [x] All 10 existing tests continue to pass (1 pre-existing Python 3.14 regex failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)