### PR TITLE
Winnti intro/debrief slide polish + carousel templates

### DIFF
--- a/carousels/poc-revealjs/.gitignore
+++ b/carousels/poc-revealjs/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+**/*.quarto_ipynb

--- a/carousels/poc-revealjs/_quarto.yml
+++ b/carousels/poc-revealjs/_quarto.yml
@@ -1,0 +1,3 @@
+project:
+  type: default
+  output-dir: ../../_output/carousels/poc-revealjs

--- a/carousels/poc-revealjs/carousel-theme.scss
+++ b/carousels/poc-revealjs/carousel-theme.scss
@@ -1,0 +1,332 @@
+/*-- scss:defaults --*/
+$presentation-font-size-root: 28px;
+$body-bg: #0d1117;
+$body-color: #f0f6fc;
+$link-color: #55A9FF;
+
+/*-- scss:rules --*/
+
+@font-face {
+  font-family: 'Minecraft';
+  src: url('../../_scss/fonts/minecraft.woff2') format('woff2');
+}
+
+.reveal { font-family: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, sans-serif; }
+
+/* Kill all RevealJS chrome */
+.reveal .controls,
+.reveal .progress,
+.reveal .slide-number,
+.reveal .slide-menu-button,
+.reveal .slide-menu-wrapper { display: none !important; }
+
+.reveal .slides section {
+  text-align: left;
+  padding: 50px 60px 70px;
+  box-sizing: border-box;
+  background-image: radial-gradient(circle, rgba(255,255,255,0.05) 1.5px, transparent 1.5px);
+  background-size: 28px 28px;
+  height: 100%;
+  display: flex !important;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.reveal .slides section h1,
+.reveal .slides section h2,
+.reveal .slides section h3 {
+  text-transform: none;
+  text-shadow: none;
+  font-family: 'Minecraft', monospace;
+  margin: 0; padding: 0;
+}
+
+:root {
+  --bg: #0d1117; --surface: #161b22; --elevated: #21262d;
+  --txt: #f0f6fc; --txt2: #c9d1d9; --muted: #8b949e;
+  --blue: #0033FF; --red: #ED1C24; --green: #27AE60; --orange: #FF6B00; --accent: #55A9FF;
+}
+
+/* === FOOTER on every slide === */
+.reveal .slides section::after {
+  content: 'MALWARE & MONSTERS';
+  position: absolute;
+  bottom: 16px; left: 60px;
+  font-family: 'Minecraft', monospace;
+  font-size: 14px; color: var(--txt2);
+  letter-spacing: 1px;
+}
+.reveal .slides section::before {
+  content: 'malwareandmonsters.com';
+  position: absolute;
+  bottom: 16px; right: 60px;
+  font-size: 13px; color: var(--accent);
+  z-index: 10;
+}
+
+/* === SLIDE 1: HOOK === */
+.slide-hook { text-align: center !important; }
+.hook-badge {
+  font-family: 'Minecraft', monospace;
+  font-size: 13px; letter-spacing: 3px; color: var(--muted);
+  border: 1px solid var(--elevated);
+  padding: 6px 18px;
+  display: inline-block;
+  margin-top: 40px;
+}
+.hook-image { margin-top: 30px; }
+.hook-image img { image-rendering: pixelated; }
+.hook-title {
+  font-family: 'Minecraft', monospace;
+  font-size: 72px; color: var(--blue);
+  text-shadow: 0 0 12px rgba(0,51,255,0.7), 0 0 40px rgba(0,51,255,0.4);
+  margin-top: 24px; letter-spacing: 2px; text-align: center;
+}
+.hook-subtitle {
+  font-size: 30px; color: var(--txt2); margin-top: 16px; text-align: center;
+}
+.threat-stars {
+  font-family: 'Minecraft', monospace;
+  font-size: 36px; letter-spacing: 8px; color: var(--red);
+  margin-top: 12px; text-align: center;
+}
+
+/* === SLIDE 2: STATS === */
+.slide-stats { display: flex; flex-direction: column; justify-content: center; align-items: center; }
+.stats-heading {
+  font-family: 'Minecraft', monospace;
+  font-size: 38px; color: var(--red);
+  text-shadow: 0 0 10px rgba(237,28,36,0.5);
+  text-align: center; width: 100%;
+}
+.stats-heading::after {
+  content: ''; display: block;
+  width: 100%; height: 3px;
+  background: var(--red); box-shadow: 0 0 8px rgba(237,28,36,0.5);
+  margin: 16px auto 40px;
+}
+.stats-grid {
+  display: flex !important; justify-content: space-around; align-items: center; width: 100%;
+}
+.stat-item { text-align: center; flex: 1; }
+.stat-number {
+  font-family: 'Minecraft', monospace; font-size: 88px; line-height: 1; margin-bottom: 16px;
+}
+.stat-red .stat-number { color: var(--red); }
+.stat-orange .stat-number { color: var(--orange); }
+.stat-blue .stat-number { color: var(--accent); }
+.stat-label {
+  font-size: 17px; color: var(--muted); text-transform: uppercase;
+  letter-spacing: 2px; line-height: 1.5; white-space: pre-line;
+}
+.stat-divider { width: 1px; height: 140px; background: rgba(255,255,255,0.1); flex-shrink: 0; }
+.stats-context {
+  font-size: 24px; color: var(--txt2); line-height: 1.6;
+  text-align: center; max-width: 800px;
+  margin: 48px auto 0; padding: 28px 36px;
+  border: 1px solid var(--elevated); border-radius: 10px;
+  background: rgba(255,255,255,0.03);
+}
+.stats-caption {
+  font-size: 16px; color: var(--muted); text-transform: uppercase;
+  letter-spacing: 2px; text-align: center; margin-top: 40px;
+}
+
+/* === SLIDE 3: PROFILE === */
+.slide-profile { border-left: 6px solid var(--blue); }
+.profile-heading {
+  font-family: 'Minecraft', monospace;
+  font-size: 44px; color: var(--blue);
+  text-shadow: 0 0 10px rgba(0,51,255,0.5);
+  margin-top: 40px; margin-bottom: 8px;
+}
+.profile-heading::after {
+  content: ''; display: block;
+  width: 140px; height: 4px; background: var(--blue);
+  box-shadow: 0 0 8px rgba(0,51,255,0.5); margin: 14px 0;
+}
+.profile-table table {
+  font-size: 26px; width: 90%; border-collapse: collapse;
+}
+.profile-table td {
+  padding: 16px 12px; border: none !important;
+  background: transparent !important; color: var(--txt2); vertical-align: top;
+}
+.profile-table td:first-child {
+  color: var(--muted); width: 170px; font-size: 18px;
+  text-transform: uppercase; letter-spacing: 1px;
+}
+.profile-table strong { color: var(--txt); }
+.profile-table tr { background: transparent !important; }
+/* Background creature stencil -- pixelated for pixel art */
+.reveal .slide-background-content {
+  image-rendering: pixelated;
+}
+
+/* === SLIDE 4: THREAT PROFILE (custom gauge) === */
+.threat-heading {
+  font-family: 'Minecraft', monospace;
+  font-size: 40px; color: var(--red);
+  text-shadow: 0 0 10px rgba(237,28,36,0.5);
+  margin-top: 30px; margin-bottom: 32px;
+}
+.threat-heading::after {
+  content: ''; display: block;
+  width: 140px; height: 4px; background: var(--red);
+  box-shadow: 0 0 8px rgba(237,28,36,0.5); margin: 12px 0 0;
+}
+.threat-gauge { text-align: center; margin: 24px 0 36px; }
+.gauge-circle {
+  width: 220px; height: 220px;
+  border: 14px solid var(--red);
+  border-radius: 50%;
+  display: inline-flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  box-shadow: 0 0 20px rgba(237,28,36,0.4), 0 0 60px rgba(237,28,36,0.15);
+}
+.gauge-score {
+  font-family: 'Minecraft', monospace;
+  font-size: 56px; color: var(--txt); line-height: 1;
+}
+.gauge-label {
+  font-size: 13px; color: var(--muted); letter-spacing: 2px; margin-top: 4px;
+}
+.stat-bars { margin-top: 8px; }
+.bar-row {
+  display: flex !important; align-items: center; margin-bottom: 14px;
+}
+.bar-label {
+  font-family: 'Minecraft', monospace;
+  font-size: 15px; color: var(--txt2); width: 140px;
+  letter-spacing: 1px;
+}
+.bar-track {
+  flex: 1; height: 28px; background: var(--elevated);
+  border-radius: 5px; overflow: hidden; margin: 0 12px;
+}
+.bar-fill {
+  height: 100%; border-radius: 5px;
+}
+.bar-orange { background: var(--orange); }
+.bar-red { background: var(--red); }
+.bar-value {
+  font-family: 'Minecraft', monospace; font-size: 22px; width: 40px; text-align: right;
+}
+.text-orange { color: var(--orange) !important; }
+.threat-summary {
+  font-size: 17px; color: var(--muted); text-transform: uppercase;
+  letter-spacing: 2px; text-align: center; margin-top: 24px;
+}
+.text-red { color: var(--red) !important; text-shadow: 0 0 10px rgba(237,28,36,0.4); }
+.text-blue { color: var(--blue) !important; text-shadow: 0 0 10px rgba(0,51,255,0.4); }
+.text-white { color: #f0f6fc !important; }
+
+/* === SLIDES 5-6: ABILITY / ATTACK === */
+.slide-ability { border-left: 6px solid var(--red); }
+.slide-attack { border-left: 6px solid var(--blue); }
+.ability-label {
+  font-family: 'Minecraft', monospace;
+  font-size: 22px; letter-spacing: 3px; margin-top: 30px; margin-bottom: 8px;
+}
+.ability-name {
+  font-family: 'Minecraft', monospace;
+  font-size: 48px; letter-spacing: 1px; line-height: 1.15; margin-bottom: 24px;
+}
+.ability-desc {
+  font-size: 28px; color: var(--txt2); margin-top: 20px;
+  max-width: 560px; line-height: 1.55;
+}
+/* Mermaid diagrams */
+.slide-ability .cell-output-display,
+.slide-attack .cell-output-display { margin: 8px 0; }
+
+/* --- Flow grid (2x2 numbered steps) --- */
+.flow-grid {
+  display: grid !important;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-top: 24px;
+  width: 100%;
+}
+.flow-step {
+  border-radius: 10px;
+  padding: 22px 20px;
+  font-size: 22px;
+  line-height: 1.45;
+  color: var(--txt2);
+}
+.flow-step strong {
+  display: block;
+  font-family: 'Minecraft', monospace;
+  font-size: 15px;
+  letter-spacing: 2px;
+  margin-bottom: 8px;
+  color: var(--txt);
+}
+.flow-red {
+  background: rgba(237,28,36,0.1);
+  border: 2px solid rgba(237,28,36,0.7);
+}
+.flow-red strong { color: var(--red); }
+.flow-blue {
+  background: rgba(0,51,255,0.1);
+  border: 2px solid rgba(0,51,255,0.7);
+}
+.flow-blue strong { color: var(--blue); }
+.flow-number {
+  font-family: 'Minecraft', monospace;
+  font-size: 40px;
+  opacity: 0.4;
+  line-height: 1;
+  margin-bottom: 4px;
+}
+.flow-red .flow-number { color: var(--red); }
+.flow-blue .flow-number { color: var(--blue); }
+
+/* === SLIDE 7: WEAKNESS === */
+.before-after {
+  display: flex !important; gap: 24px; margin-top: 28px; width: 75%;
+}
+.ba-before, .ba-after {
+  flex: 1; border-radius: 10px; padding: 28px 24px;
+  font-size: 26px; line-height: 1.55;
+}
+.ba-before {
+  background: rgba(237,28,36,0.12); border: 1px solid rgba(237,28,36,0.35);
+  color: rgba(255,255,255,0.85);
+}
+.ba-after {
+  background: rgba(39,174,96,0.12); border: 1px solid rgba(39,174,96,0.35);
+  color: rgba(255,255,255,0.85);
+}
+.ba-before strong, .ba-after strong {
+  font-family: 'Minecraft', monospace;
+  font-size: 16px; letter-spacing: 3px; display: block; margin-bottom: 14px;
+}
+.ba-before strong { color: var(--red); }
+.ba-after strong { color: var(--green); }
+/* ghost-light no longer needed -- creature is now a background image */
+
+/* === SLIDE 8: CTA === */
+.slide-cta {
+  text-align: center !important;
+}
+.cta-content {
+  text-align: center; width: 100%;
+}
+.cta-icon { font-size: 120px; margin-bottom: 24px; }
+.cta-heading {
+  font-family: 'Minecraft', monospace;
+  font-size: 56px; color: #ffffff; text-align: center;
+  text-shadow: 0 0 20px rgba(255,255,255,0.3);
+  line-height: 1.3; margin-bottom: 44px;
+}
+.cta-button {
+  font-family: 'Minecraft', monospace;
+  font-size: 26px; color: var(--blue); background: white;
+  padding: 22px 48px; border-radius: 8px; display: inline-block;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.3), 0 0 30px rgba(255,255,255,0.15);
+}
+.cta-url {
+  font-size: 18px; color: rgba(255,255,255,0.55); text-align: center; margin-top: 24px;
+}

--- a/carousels/poc-revealjs/lockbit.qmd
+++ b/carousels/poc-revealjs/lockbit.qmd
@@ -1,0 +1,333 @@
+---
+title: ""
+format:
+  revealjs:
+    width: 1080
+    height: 1350
+    margin: 0
+    center: false
+    controls: false
+    progress: false
+    slide-number: false
+    hash: false
+    history: false
+    transition: none
+    theme: carousel-theme.scss
+    incremental: false
+    navigation-mode: linear
+    menu: false
+metadata:
+  pagetitle: "LockBit - Meet the Malmon"
+---
+
+## {.slide-hook data-background-color="#0d1117"}
+
+::: {.hook-badge}
+MEET THE MALMON
+:::
+
+::: {.hook-image}
+![](../../im-handbook/resources/malmon-images/lockbit.gif){width="380"}
+:::
+
+::: {.hook-title}
+LockBit
+:::
+
+::: {.hook-subtitle}
+This ransomware gang made $91M in 2023.
+:::
+
+::: {.threat-stars}
+★★★☆☆
+:::
+
+
+## {.slide-stats data-background-color="#161b22"}
+
+::: {.stats-heading}
+BY THE NUMBERS
+:::
+
+:::: {.stats-grid}
+::: {.stat-item .stat-red}
+::: {.stat-number}
+$91M
+:::
+::: {.stat-label}
+Ransom revenue
+in 2023
+:::
+:::
+::: {.stat-divider}
+:::
+::: {.stat-item .stat-orange}
+::: {.stat-number}
+1,653
+:::
+::: {.stat-label}
+Organizations
+attacked
+:::
+:::
+::: {.stat-divider}
+:::
+::: {.stat-item .stat-blue}
+::: {.stat-number}
+11
+:::
+::: {.stat-label}
+Minutes to
+encrypt a disk
+:::
+:::
+::::
+
+::: {.stats-context}
+LockBit operated the most prolific ransomware-as-a-service program in history, until a multinational law enforcement takedown in February 2024 disrupted their infrastructure.
+:::
+
+::: {.stats-caption}
+REAL-WORLD IMPACT OF LOCKBIT
+:::
+
+
+## {.slide-profile data-background-color="#0d1117" data-background-image="../../im-handbook/resources/malmon-images/lockbit.gif" data-background-size="480px" data-background-position="center 50%" data-background-opacity="0.1"}
+
+::: {.profile-heading}
+CREATURE PROFILE
+:::
+
+::: {.profile-table}
+| | |
+|---|---|
+| **Name** | Winwareia Cryptor Lockbitium |
+| **Classification** | Global 2019 |
+| **Type** | Ransomware / Criminal |
+| **Habitat** | Enterprise networks, high-value targets |
+| **Discovered by** | Security Vendors |
+| **Active** | September 2019 -- February 2024 |
+| **Victims** | 1,653+ organizations across 78 countries |
+| **Status** | Disrupted by multinational law enforcement |
+:::
+
+
+## {.slide-threat data-background-color="#161b22"}
+
+::: {.threat-heading}
+THREAT PROFILE
+:::
+
+::: {.threat-gauge}
+::: {.gauge-circle}
+::: {.gauge-score}
+7.4
+:::
+::: {.gauge-label}
+OUT OF 10
+:::
+:::
+:::
+
+::: {.stat-bars}
+::: {.bar-row}
+::: {.bar-label}
+DETECTION
+:::
+::: {.bar-track}
+::: {.bar-fill .bar-orange style="width: 50%"}
+:::
+:::
+::: {.bar-value .text-orange}
+5
+:::
+:::
+::: {.bar-row}
+::: {.bar-label}
+PERSISTENCE
+:::
+::: {.bar-track}
+::: {.bar-fill .bar-red style="width: 70%"}
+:::
+:::
+::: {.bar-value .text-red}
+7
+:::
+:::
+::: {.bar-row}
+::: {.bar-label}
+SPREAD
+:::
+::: {.bar-track}
+::: {.bar-fill .bar-red style="width: 80%"}
+:::
+:::
+::: {.bar-value .text-red}
+8
+:::
+:::
+::: {.bar-row}
+::: {.bar-label}
+PAYLOAD
+:::
+::: {.bar-track}
+::: {.bar-fill .bar-red style="width: 100%"}
+:::
+:::
+::: {.bar-value .text-red}
+10
+:::
+:::
+::: {.bar-row}
+::: {.bar-label}
+EVASION
+:::
+::: {.bar-track}
+::: {.bar-fill .bar-red style="width: 70%"}
+:::
+:::
+::: {.bar-value .text-red}
+7
+:::
+:::
+:::
+
+::: {.threat-summary}
+HIGHER THAN 94% OF KNOWN RANSOMWARE FAMILIES
+:::
+
+
+## {.slide-ability data-background-color="#0d1117" data-background-image="../../im-handbook/resources/malmon-images/lockbit.gif" data-background-size="520px" data-background-position="center 50%" data-background-opacity="0.08"}
+
+::: {.ability-label .text-red}
+⚡ PRIMARY ABILITY
+:::
+
+::: {.ability-name .text-red}
+Ransomware-as-a-Service
+:::
+
+:::: {.flow-grid}
+::: {.flow-step .flow-red}
+::: {.flow-number}
+1
+:::
+**RECRUIT**
+Affiliates join via darknet portal. 75-80% revenue share.
+:::
+::: {.flow-step .flow-red}
+::: {.flow-number}
+2
+:::
+**DEPLOY**
+Stolen credentials or phishing. Initial access in hours.
+:::
+::: {.flow-step .flow-red}
+::: {.flow-number}
+3
+:::
+**ENCRYPT**
+Full disk encryption in 11 minutes. Fastest in class.
+:::
+::: {.flow-step .flow-red}
+::: {.flow-number}
+4
+:::
+**EXTORT**
+Pay ransom or sensitive data published on leak site.
+:::
+::::
+
+
+## {.slide-attack data-background-color="#0d1117" data-background-image="../../im-handbook/resources/malmon-images/lockbit.gif" data-background-size="520px" data-background-position="center 50%" data-background-opacity="0.08"}
+
+::: {.ability-label .text-blue}
+⊕ SPECIAL ATTACK
+:::
+
+::: {.ability-name .text-blue}
+Double Extortion
+:::
+
+:::: {.flow-grid}
+::: {.flow-step .flow-blue}
+::: {.flow-number}
+1
+:::
+**ENCRYPT**
+Lock every file on every system. Operations halt.
+:::
+::: {.flow-step .flow-blue}
+::: {.flow-number}
+2
+:::
+**EXFILTRATE**
+Copy sensitive data to attacker-controlled servers.
+:::
+::: {.flow-step .flow-blue}
+::: {.flow-number}
+3
+:::
+**THREATEN**
+Countdown timer on public leak site. Media notified.
+:::
+::: {.flow-step .flow-blue}
+::: {.flow-number}
+4
+:::
+**PRESSURE**
+Regulatory exposure. Client notification. Stock impact.
+:::
+::::
+
+
+## {.slide-weakness data-background="linear-gradient(160deg, #0d1117 0%, #0f3d20 50%, #27AE60 100%)"}
+
+::: {.ability-label .text-white}
+🛡 HOW TO DEFEAT IT
+:::
+
+::: {.ability-name .text-white}
+Backup Systems
+:::
+
+:::: {.before-after}
+::: {.ba-before}
+**WITHOUT**
+
+Average dwell time: 21 days.\
+Recovery time: 23 days.\
+Average ransom: $1.5M.\
+40% of victims pay.
+:::
+::: {.ba-after}
+**WITH BACKUPS**
+
+Encryption is reversible.\
+Recovery time: 4-8 hours.\
+Ransom paid: $0.\
+Business continues.
+:::
+::::
+
+
+## {.slide-cta data-background="linear-gradient(160deg, #0d1117 0%, #001a80 50%, #0033FF 100%)"}
+
+::: {.cta-content}
+::: {.cta-icon}
+🎮
+:::
+
+::: {.cta-heading}
+WANT TO FIGHT
+THIS MALMON?
+:::
+
+::: {.cta-button}
+Run the LockBit scenarios →
+:::
+
+::: {.cta-url}
+malwareandmonsters.com
+:::
+:::

--- a/carousels/poc-typst/lockbit.qmd
+++ b/carousels/poc-typst/lockbit.qmd
@@ -1,0 +1,14 @@
+---
+title: ""
+format:
+  typst:
+    template-partials:
+      - typst-show.typ
+      - typst-template.typ
+    keep-typ: true
+    margin:
+      top: 60pt
+      bottom: 90pt
+      left: 60pt
+      right: 60pt
+---

--- a/carousels/poc-typst/lockbit.typ
+++ b/carousels/poc-typst/lockbit.typ
@@ -1,0 +1,285 @@
+// LockBit Carousel -- Typst PoC v6 (regime-compliant)
+// Compile: quarto typst compile carousels/poc-typst/lockbit.typ --root . --font-path _scss/fonts/
+
+#let page-w = 15in
+#let page-h = 18.75in
+
+#let bg = rgb("#0d1117")
+#let surface = rgb("#161b22")
+#let elevated = rgb("#21262d")
+#let txt = rgb("#f0f6fc")
+#let txt2 = rgb("#c9d1d9")
+#let muted = rgb("#8b949e")
+#let blue = rgb("#0033FF")
+#let red = rgb("#ED1C24")
+#let green = rgb("#27AE60")
+#let orange = rgb("#FF6B00")
+#let accent = rgb("#55A9FF")
+
+#let mm-footer() = {
+  line(length: 100%, stroke: 0.5pt + rgb("#ffffff18"))
+  v(10pt)
+  grid(columns: (1fr, 1fr),
+    text(font: "Minecraft", size: 14pt, fill: txt2, tracking: 1pt)[MALWARE & MONSTERS],
+    align(right, text(size: 13pt, fill: accent)[malwareandmonsters.com]),
+  )
+}
+
+#let stat-bar(label, value, max: 10) = {
+  let pct = calc.round(value / max * 100)
+  let color = if value <= 3 { green } else if value <= 6 { orange } else { red }
+  grid(columns: (140pt, 1fr, 50pt), align: horizon, gutter: 14pt,
+    text(font: "Minecraft", size: 16pt, fill: txt2, tracking: 1pt)[#upper(label)],
+    box(width: 100%, height: 32pt, fill: elevated, radius: 5pt,
+      box(width: pct * 1%, height: 32pt, fill: color, radius: 5pt)
+    ),
+    text(font: "Minecraft", size: 26pt, fill: color)[#str(value)],
+  )
+}
+
+#let flow-step(number, label, desc, color: red) = {
+  box(width: 100%, inset: (x: 18pt, y: 18pt), radius: 10pt,
+    stroke: 2pt + color, fill: color.transparentize(87%),
+  )[
+    #text(font: "Minecraft", size: 36pt, fill: color.transparentize(50%))[#str(number)]
+    #v(6pt)
+    #text(font: "Minecraft", size: 14pt, fill: muted, tracking: 2pt)[#upper(label)]
+    #v(8pt)
+    #text(size: 22pt, fill: txt)[#desc]
+  ]
+}
+
+// Creature stencil -- faint, placed high so it doesn't compete with content
+#let creature-bg(bg-color: bg, size: 400pt, opacity-hex: "e8") = {
+  place(center, dy: 40pt,
+    block(clip: true, width: size, height: size)[
+      #image("../../im-handbook/resources/malmon-images/lockbit.gif", width: size)
+      #place(top + left, rect(width: 100%, height: 100%, fill: rgb(bg-color.to-hex().slice(0, 7) + opacity-hex)))
+    ],
+  )
+}
+
+
+// ============ SLIDE 1: HOOK ============
+#set page(width: page-w, height: page-h, margin: (top: 50pt, bottom: 80pt, left: 60pt, right: 60pt), fill: bg, footer: mm-footer())
+
+#v(1fr)
+#align(center, box(stroke: 0.5pt + elevated, inset: (x: 16pt, y: 8pt), radius: 4pt)[
+  #text(font: "Minecraft", size: 12pt, fill: muted, tracking: 3pt)[MEET THE MALMON]
+])
+#v(30pt)
+#align(center, image("../../im-handbook/resources/malmon-images/lockbit.gif", width: 340pt))
+#v(24pt)
+#align(center, text(font: "Minecraft", size: 64pt, fill: blue)[LockBit])
+#v(14pt)
+#align(center, text(size: 28pt, fill: txt2)[This ransomware gang made \$91M in 2023.])
+#v(14pt)
+#align(center, text(font: "Minecraft", size: 36pt, fill: red, tracking: 6pt)[★★★☆☆])
+#v(1fr)
+
+
+// ============ SLIDE 2: BY THE NUMBERS ============
+#set page(fill: surface)
+
+#v(1fr)
+#align(center, text(font: "Minecraft", size: 40pt, fill: red)[BY THE NUMBERS])
+#v(8pt)
+#line(length: 100%, stroke: 3pt + red)
+#v(48pt)
+
+#grid(columns: (1fr, 1pt, 1fr, 1pt, 1fr), align: center + horizon, gutter: 24pt,
+  stack(dir: ttb, spacing: 18pt,
+    text(font: "Minecraft", size: 88pt, fill: red)[\$91M],
+    text(size: 17pt, fill: muted, tracking: 2pt)[RANSOM REVENUE\ IN 2023],
+  ),
+  line(angle: 90deg, length: 160pt, stroke: 0.5pt + rgb("#ffffff1a")),
+  stack(dir: ttb, spacing: 18pt,
+    text(font: "Minecraft", size: 88pt, fill: orange)[1,653],
+    text(size: 17pt, fill: muted, tracking: 2pt)[ORGANIZATIONS\ ATTACKED],
+  ),
+  line(angle: 90deg, length: 160pt, stroke: 0.5pt + rgb("#ffffff1a")),
+  stack(dir: ttb, spacing: 18pt,
+    text(font: "Minecraft", size: 88pt, fill: accent)[11],
+    text(size: 17pt, fill: muted, tracking: 2pt)[MINUTES TO\ ENCRYPT A DISK],
+  ),
+)
+
+#v(48pt)
+
+#box(width: 100%, inset: (x: 32pt, y: 24pt), radius: 10pt,
+  fill: rgb("#ffffff06"), stroke: 0.5pt + elevated,
+)[
+  #text(size: 24pt, fill: txt2)[
+    LockBit operated the most prolific ransomware-as-a-service program in history, until a multinational law enforcement takedown in February 2024 disrupted their infrastructure.
+  ]
+]
+
+#v(1fr)
+#line(length: 100%, stroke: 0.5pt + rgb("#ffffff0d"))
+#v(14pt)
+#align(center, text(size: 17pt, fill: muted, tracking: 2pt)[REAL-WORLD IMPACT OF LOCKBIT])
+
+
+// ============ SLIDE 3: CREATURE PROFILE ============
+#set page(fill: bg)
+#place(left, dx: -60pt, rect(width: 6pt, height: page-h, fill: blue))
+#creature-bg(bg-color: bg, size: 420pt, opacity-hex: "e0")
+
+#v(1fr)
+#text(font: "Minecraft", size: 48pt, fill: blue)[CREATURE PROFILE]
+#v(8pt)
+#line(length: 160pt, stroke: 4pt + blue)
+#v(36pt)
+
+#let profile-row(label, value) = {
+  grid(columns: (170pt, 1fr), gutter: 16pt,
+    text(font: "Minecraft", size: 17pt, fill: muted, tracking: 1pt)[#upper(label)],
+    text(size: 26pt, fill: txt2)[#value],
+  )
+}
+
+#stack(dir: ttb, spacing: 28pt,
+  profile-row("Name", text(fill: txt, weight: "bold")[Winwareia Cryptor Lockbitium]),
+  profile-row("Classification", [Global 2019]),
+  profile-row("Type", text(fill: blue, weight: "bold")[Ransomware / Criminal]),
+  profile-row("Habitat", [Enterprise networks, high-value targets]),
+  profile-row("Discovered by", [Security Vendors]),
+  profile-row("Active", [September 2019 -- February 2024]),
+  profile-row("Victims", text(fill: red)[1,653+ organizations across 78 countries]),
+  profile-row("Status", text(fill: red)[Disrupted by multinational law enforcement]),
+)
+#v(1fr)
+
+
+// ============ SLIDE 4: THREAT PROFILE ============
+#set page(fill: surface)
+
+#v(1fr)
+#text(font: "Minecraft", size: 40pt, fill: red)[THREAT PROFILE]
+#v(6pt)
+#line(length: 160pt, stroke: 4pt + red)
+#v(32pt)
+
+#align(center)[
+  #box(width: 260pt, height: 260pt)[
+    #place(center + horizon, circle(radius: 116pt, stroke: 18pt + red, fill: surface))
+    #place(center + horizon,
+      stack(dir: ttb, spacing: 8pt,
+        text(font: "Minecraft", size: 72pt, fill: txt)[7.4],
+        text(size: 14pt, fill: muted, tracking: 2pt)[OUT OF 10],
+        text(font: "Minecraft", size: 11pt, fill: red, tracking: 3pt)[THREAT LEVEL],
+      )
+    )
+  ]
+]
+
+#v(32pt)
+
+#stack(dir: ttb, spacing: 18pt,
+  stat-bar("Detection", 5),
+  stat-bar("Persistence", 7),
+  stat-bar("Spread", 8),
+  stat-bar("Payload", 10),
+  stat-bar("Evasion", 7),
+)
+
+#v(28pt)
+#align(center, text(size: 20pt, fill: muted, tracking: 1pt)[
+  HIGHER THAN 94% OF KNOWN RANSOMWARE FAMILIES
+])
+#v(1fr)
+
+
+// ============ SLIDE 5: PRIMARY ABILITY ============
+#set page(fill: bg)
+#place(left, dx: -60pt, rect(width: 6pt, height: page-h, fill: red))
+#creature-bg(bg-color: bg, size: 440pt, opacity-hex: "e8")
+
+#v(1fr)
+#text(font: "Minecraft", size: 22pt, fill: red, tracking: 3pt)[⚡ PRIMARY ABILITY]
+#v(6pt)
+#line(length: 160pt, stroke: 3pt + red)
+#v(24pt)
+#text(font: "Minecraft", size: 52pt, fill: red)[Ransomware-as-a-Service]
+#v(36pt)
+
+// Kill chain -- LARGE numbered steps, one idea
+#grid(columns: (1fr, 1fr), gutter: 20pt,
+  flow-step(1, "Recruit", "Affiliates join via darknet portal. 75--80% revenue share.", color: red),
+  flow-step(2, "Deploy", "Stolen credentials or phishing. Initial access in hours.", color: red),
+  flow-step(3, "Encrypt", "Full disk encryption in 11 minutes. Fastest in class.", color: red),
+  flow-step(4, "Extort", "Pay ransom or sensitive data published on leak site.", color: red),
+)
+#v(1fr)
+
+
+// ============ SLIDE 6: SPECIAL ATTACK ============
+#set page(fill: bg)
+#place(left, dx: -60pt, rect(width: 6pt, height: page-h, fill: blue))
+#creature-bg(bg-color: bg, size: 440pt, opacity-hex: "e8")
+
+#v(1fr)
+#text(font: "Minecraft", size: 22pt, fill: blue, tracking: 3pt)[⊕ SPECIAL ATTACK]
+#v(6pt)
+#line(length: 160pt, stroke: 3pt + blue)
+#v(24pt)
+#text(font: "Minecraft", size: 52pt, fill: blue)[Double Extortion]
+#v(36pt)
+
+#grid(columns: (1fr, 1fr), gutter: 20pt,
+  flow-step(1, "Encrypt", "Lock every file on every system. Operations halt.", color: blue),
+  flow-step(2, "Exfiltrate", "Copy sensitive data to attacker-controlled servers.", color: blue),
+  flow-step(3, "Threaten", "Countdown timer on public leak site. Media notified.", color: blue),
+  flow-step(4, "Pressure", "Regulatory exposure. Client notification. Stock impact.", color: blue),
+)
+#v(1fr)
+
+
+// ============ SLIDE 7: WEAKNESS ============
+#set page(fill: gradient.linear(rgb("#0d1117"), rgb("#0f3d20"), rgb("#1a6b3c"), angle: 160deg))
+
+#v(1fr)
+#text(font: "Minecraft", size: 22pt, fill: white, tracking: 3pt)[🛡 HOW TO DEFEAT IT]
+#v(6pt)
+#line(length: 160pt, stroke: 3pt + rgb("#ffffff88"))
+#v(24pt)
+#text(font: "Minecraft", size: 52pt, fill: white)[Backup Systems]
+#v(36pt)
+
+#grid(columns: (1fr, 1fr), gutter: 24pt,
+  box(width: 100%, inset: 28pt, radius: 12pt, fill: red.transparentize(84%), stroke: 1.5pt + red.transparentize(55%))[
+    #text(font: "Minecraft", size: 18pt, fill: red, tracking: 3pt)[WITHOUT]
+    #v(18pt)
+    #set text(size: 24pt, fill: rgb("#ffffffdd"))
+    Average dwell time: 21 days.\
+    Recovery time: 23 days.\
+    Average ransom: \$1.5M.\
+    40% of victims pay.
+  ],
+  box(width: 100%, inset: 28pt, radius: 12pt, fill: green.transparentize(84%), stroke: 1.5pt + green.transparentize(55%))[
+    #text(font: "Minecraft", size: 18pt, fill: green, tracking: 3pt)[WITH BACKUPS]
+    #v(18pt)
+    #set text(size: 24pt, fill: rgb("#ffffffdd"))
+    Encryption is reversible.\
+    Recovery time: 4--8 hours.\
+    Ransom paid: \$0.\
+    Business continues.
+  ],
+)
+#v(1fr)
+
+
+// ============ SLIDE 8: CTA ============
+#set page(fill: gradient.linear(rgb("#0d1117"), rgb("#001a80"), rgb("#0033FF"), angle: 160deg))
+
+#v(1fr)
+#align(center, text(size: 110pt)[🎮])
+#v(28pt)
+#align(center, text(font: "Minecraft", size: 56pt, fill: white)[WANT TO FIGHT\ THIS MALMON?])
+#v(44pt)
+#align(center, box(inset: (x: 48pt, y: 22pt), radius: 8pt, fill: white)[
+  #text(font: "Minecraft", size: 26pt, fill: blue)[Run the LockBit scenarios →]
+])
+#v(28pt)
+#align(center, text(size: 18pt, fill: rgb("#ffffff99"))[malwareandmonsters.com])
+#v(1fr)

--- a/carousels/poc-typst/typst-template.typ
+++ b/carousels/poc-typst/typst-template.typ
@@ -1,0 +1,89 @@
+// LinkedIn Carousel Template for Malware & Monsters
+// 1080x1350px at 72dpi = 15in x 18.75in
+
+#let page-w = 15in
+#let page-h = 18.75in
+
+// Brand colors
+#let col-bg = rgb("#0d1117")
+#let col-surface = rgb("#161b22")
+#let col-elevated = rgb("#21262d")
+#let col-text = rgb("#f0f6fc")
+#let col-text2 = rgb("#c9d1d9")
+#let col-muted = rgb("#8b949e")
+#let col-blue = rgb("#0033FF")
+#let col-red = rgb("#ED1C24")
+#let col-green = rgb("#27AE60")
+#let col-orange = rgb("#FF6B00")
+#let col-purple = rgb("#9B59B6")
+#let col-accent = rgb("#55A9FF")
+
+// Slide function
+#let slide(bg: col-bg, accent: none, body) = {
+  pagebreak(weak: true)
+  set page(
+    width: page-w,
+    height: page-h,
+    margin: (top: 60pt, bottom: 90pt, left: 60pt, right: 60pt),
+    fill: bg,
+    footer: {
+      line(length: 100%, stroke: 0.5pt + rgb("#ffffff18"))
+      v(10pt)
+      grid(
+        columns: (1fr, 1fr),
+        text(size: 16pt, fill: col-text2, tracking: 1pt)[*MALWARE & MONSTERS*],
+        align(right, text(size: 14pt, fill: col-accent)[malwareandmonsters.com]),
+      )
+    },
+  )
+  if accent != none {
+    place(left, dx: -60pt, rect(width: 6pt, height: page-h, fill: accent))
+  }
+  body
+}
+
+// Stat bar component
+#let stat-bar(label, value, max: 10) = {
+  let pct = value / max * 100%
+  let color = if value <= 3 { col-green } else if value <= 6 { col-orange } else { col-red }
+  grid(
+    columns: (130pt, 1fr, 50pt),
+    align: horizon,
+    gutter: 12pt,
+    text(size: 16pt, fill: col-text2, tracking: 1pt, weight: "bold")[#upper(label)],
+    box(width: 100%, height: 28pt, fill: col-elevated, radius: 5pt,
+      box(width: pct, height: 28pt, fill: color, radius: 5pt)
+    ),
+    text(size: 22pt, fill: color, weight: "bold")[#str(value)],
+  )
+}
+
+// Flow box component (for kill chains)
+#let flow-box(label, desc, color: col-red) = {
+  box(
+    width: 100%,
+    inset: (x: 14pt, y: 12pt),
+    radius: 8pt,
+    stroke: 1.5pt + color,
+    fill: color.transparentize(88%),
+  )[
+    #text(size: 11pt, fill: col-muted, tracking: 2pt, weight: "bold")[#upper(label)]
+    #v(4pt)
+    #text(size: 18pt, fill: col-text)[#desc]
+  ]
+}
+
+// Flow arrow
+#let flow-arrow(color: col-red) = {
+  align(center + horizon, text(size: 28pt, fill: color)[→])
+}
+
+// Document setup
+#set text(font: "Source Sans Pro", size: 22pt, fill: col-text)
+#set par(leading: 12pt)
+
+// Entry point for Quarto
+#show: body => {
+  set page(width: page-w, height: page-h, margin: 0pt, fill: col-bg)
+  body
+}

--- a/carousels/templates/base.html
+++ b/carousels/templates/base.html
@@ -124,10 +124,17 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
+    padding-top: 40px;
     width: 100%;
     position: relative;
     z-index: 1;
+  }
+
+  /* Only center content on hook/CTA slides where it's intentional */
+  .slide-content.centered {
+    justify-content: center;
+    padding-top: 0;
   }
 
   .slide-footer {
@@ -255,10 +262,10 @@
 
   .bullet-list li {
     font-size: 30px;
-    line-height: 1.3;
+    line-height: 1.4;
     color: var(--text-secondary);
-    padding: 12px 0;
-    padding-left: 36px;
+    padding: 14px 0;
+    padding-left: 40px;
     position: relative;
   }
 
@@ -312,9 +319,9 @@
 
   /* --- ACCENT LINES --- */
   .accent-line {
-    width: 120px;
-    height: 4px;
-    margin: 20px 0;
+    width: 160px;
+    height: 5px;
+    margin: 24px 0;
     border-radius: 2px;
   }
 
@@ -587,11 +594,11 @@
     display: flex;
     align-items: center;
     gap: 20px;
-    margin-bottom: 16px;
+    margin-bottom: 20px;
   }
 
   .slide-header-icon {
-    font-size: 44px;
+    font-size: 52px;
     flex-shrink: 0;
     line-height: 1;
   }
@@ -632,15 +639,15 @@
   /* --- ABILITY HEADLINE (large typographic anchor) --- */
   .ability-headline {
     font-family: 'Minecraft', monospace;
-    font-size: 60px;
+    font-size: 72px;
     line-height: 1.15;
     letter-spacing: 1px;
-    margin-bottom: 28px;
+    margin-bottom: 36px;
   }
 
   /* --- DESCRIPTION TEXT (plain, no panel) --- */
   .description-text {
-    font-size: 30px;
+    font-size: 36px;
     line-height: 1.55;
     color: var(--text-secondary);
     max-width: 820px;

--- a/carousels/templates/malmon-spotlight.html
+++ b/carousels/templates/malmon-spotlight.html
@@ -64,7 +64,7 @@
 <!-- SLIDE 5: PRIMARY ABILITY -->
 <div class="slide left-accent-red">
   <img src="{{IMAGE_PATH}}" class="malmon-bleed" alt="">
-  <div class="slide-content" style="justify-content: flex-start; padding-top: 20px;">
+  <div class="slide-content">
     <div class="slide-header">
       <i class="fa-solid fa-bolt slide-header-icon neon-red" style="color: var(--brand-red);"></i>
       <div class="heading-md text-red neon-red">PRIMARY ABILITY</div>
@@ -83,7 +83,7 @@
 <!-- SLIDE 6: SPECIAL ATTACK -->
 <div class="slide bg-gradient-dark">
   <img src="{{IMAGE_PATH}}" class="malmon-bleed" alt="">
-  <div class="slide-content" style="justify-content: flex-start; padding-top: 20px;">
+  <div class="slide-content">
     <div class="slide-header">
       <i class="fa-solid fa-crosshairs slide-header-icon neon-blue" style="color: var(--brand-blue);"></i>
       <div class="heading-md text-blue neon-blue">SPECIAL ATTACK</div>
@@ -102,7 +102,7 @@
 <!-- SLIDE 7: WEAKNESS -->
 <div class="slide bg-gradient-green">
   <img src="{{IMAGE_PATH}}" class="malmon-bleed" alt="" style="opacity: 0.08;">
-  <div class="slide-content" style="justify-content: flex-start; padding-top: 20px;">
+  <div class="slide-content">
     <div class="slide-header">
       <i class="fa-solid fa-shield-halved slide-header-icon" style="color: rgba(255,255,255,0.9); filter: drop-shadow(0 0 8px rgba(255,255,255,0.4));"></i>
       <div class="heading-md text-white" style="opacity: 0.9;">HOW TO DEFEAT IT</div>

--- a/carousels/templates/scenario-teaser.html
+++ b/carousels/templates/scenario-teaser.html
@@ -30,12 +30,12 @@
 <!-- SLIDE 3: THE GAP / CONTEXT -->
 <div class="slide left-accent-blue">
   <div class="slide-content">
-    <div class="slide-header">
-      <i class="fa-solid fa-magnifying-glass slide-header-icon neon-blue" style="color: var(--brand-blue);"></i>
-      <div class="heading-md text-blue neon-blue">WHY THIS MATTERS</div>
+    <div style="text-align: center; margin-bottom: 20px;">
+      <i class="fa-solid fa-magnifying-glass" style="font-size: 160px; color: var(--brand-blue); opacity: 0.2; filter: drop-shadow(0 0 24px rgba(0,51,255,0.6)) drop-shadow(0 0 60px rgba(0,51,255,0.25));"></i>
     </div>
+    <div class="heading-lg text-blue neon-blue" style="margin-bottom: 12px;">WHY THIS MATTERS</div>
     <div class="accent-line blue neon-blue"></div>
-    <div class="spacer-md"></div>
+    <div class="spacer-sm"></div>
     <div class="body-lg" style="color: var(--text-primary); line-height: 1.6;">{{THE_GAP}}</div>
   </div>
   <div class="slide-footer">
@@ -49,7 +49,7 @@
   <div class="slide-content">
     <div class="slide-header">
       <i class="fa-solid fa-laptop-code slide-header-icon neon-red" style="color: var(--brand-red);"></i>
-      <div class="heading-md text-red neon-red">THE SCENARIO</div>
+      <div class="heading-lg text-red neon-red">THE SCENARIO</div>
     </div>
     <div class="accent-line red neon-red"></div>
     <div class="spacer-md"></div>
@@ -68,7 +68,7 @@
   <div class="slide-content">
     <div class="slide-header">
       <i class="fa-solid fa-fire slide-header-icon" style="color: rgba(255,255,255,0.9); filter: drop-shadow(0 0 12px rgba(255,100,0,0.8));"></i>
-      <div class="heading-md text-white" style="text-shadow: 0 0 20px rgba(255,255,255,0.3);">THE PRESSURE</div>
+      <div class="heading-lg text-white" style="text-shadow: 0 0 20px rgba(255,255,255,0.3);">THE PRESSURE</div>
     </div>
     <div class="accent-line" style="background: rgba(255,255,255,0.5); box-shadow: 0 0 8px rgba(255,255,255,0.3);"></div>
     <div class="spacer-md"></div>
@@ -85,12 +85,12 @@
 <!-- SLIDE 6: DECISION -->
 <div class="slide bg-gradient-dark">
   <div class="slide-content">
-    <div class="slide-header">
-      <i class="fa-solid fa-code-branch slide-header-icon" style="color: var(--warning-orange); filter: drop-shadow(0 0 10px rgba(255,107,0,0.7));"></i>
-      <div class="heading-md" style="color: var(--warning-orange); text-shadow: 0 0 10px rgba(255,107,0,0.8), 0 0 30px rgba(255,107,0,0.5);">WHAT DO YOU DO?</div>
+    <div style="text-align: center; margin-bottom: 20px;">
+      <i class="fa-solid fa-code-branch" style="font-size: 160px; color: var(--warning-orange); opacity: 0.2; filter: drop-shadow(0 0 24px rgba(255,107,0,0.6)) drop-shadow(0 0 60px rgba(255,107,0,0.25));"></i>
     </div>
+    <div class="heading-lg" style="color: var(--warning-orange); text-shadow: 0 0 10px rgba(255,107,0,0.8), 0 0 30px rgba(255,107,0,0.5); margin-bottom: 12px;">WHAT DO YOU DO?</div>
     <div class="accent-line orange" style="box-shadow: 0 0 8px rgba(255,107,0,0.6), 0 0 20px rgba(255,107,0,0.3);"></div>
-    <div class="spacer-md"></div>
+    <div class="spacer-sm"></div>
     {{DECISION}}
   </div>
   <div class="slide-footer">
@@ -102,12 +102,12 @@
 <!-- SLIDE 7: THE PITCH -->
 <div class="slide left-accent-green">
   <div class="slide-content">
-    <div class="slide-header">
-      <i class="fa-solid fa-graduation-cap slide-header-icon" style="color: var(--success-green); filter: drop-shadow(0 0 8px rgba(39,174,96,0.6));"></i>
-      <div class="heading-md text-green" style="filter: drop-shadow(0 0 8px rgba(39,174,96,0.5));">LEARN BY PLAYING</div>
+    <div style="text-align: center; margin-bottom: 20px;">
+      <i class="fa-solid fa-graduation-cap" style="font-size: 160px; color: var(--success-green); opacity: 0.2; filter: drop-shadow(0 0 24px rgba(39,174,96,0.6)) drop-shadow(0 0 60px rgba(39,174,96,0.25));"></i>
     </div>
+    <div class="heading-lg text-green" style="filter: drop-shadow(0 0 8px rgba(39,174,96,0.5)); margin-bottom: 12px;">LEARN BY PLAYING</div>
     <div class="accent-line green" style="box-shadow: 0 0 8px rgba(39,174,96,0.6), 0 0 20px rgba(39,174,96,0.3);"></div>
-    <div class="spacer-md"></div>
+    <div class="spacer-sm"></div>
     <div class="panel green-tint" style="width: 100%; box-shadow: 0 0 8px rgba(39,174,96,0.3), 0 0 20px rgba(39,174,96,0.15), inset 0 0 8px rgba(39,174,96,0.05);">
       <div class="body-lg" style="line-height: 1.6; color: var(--text-primary);">{{THE_PITCH}}</div>
     </div>

--- a/docs/LINKEDIN-CAROUSELS.md
+++ b/docs/LINKEDIN-CAROUSELS.md
@@ -309,19 +309,51 @@ Every content slide must have a single dominant graphical element that communica
 - An icon used as a heading decoration (72px icon above a heading above content)
 - Bars or charts used as secondary elements after text has already filled the slide
 
+### Narrative Frameworks
+
+Every carousel should follow one of these proven structures. Pick the framework before writing any slides -- it determines the slide sequence.
+
+**Problem-Solution-Result (PSR):**
+Three-act structure. Hook with a specific problem, show the solution, prove the result with concrete numbers. "Client struggled with 10% lead conversion → We implemented X → Result: 40% conversion in 90 days." Most effective for scenario teasers (Series B) and thought leadership (Series D).
+
+**Before-After Transformation:**
+Focus on a single, stark contrast. Quantify both states with specific numbers. Dedicate a middle slide to explain the "how" that drove the transformation. Split-screen layouts work well. Maps directly to the weakness slide pattern in malmon spotlights.
+
+**Myth vs Reality:**
+Contrarian format. Identify a widely-held belief, debunk it with evidence, present the corrected insight. Immediately captures attention because it challenges what the viewer thinks they know. Ideal for Series D thought leadership ("Your TTX compliance doesn't have to be miserable").
+
+**Data-Driven Insight:**
+Lead with original research, statistics, or counterintuitive findings. "We analyzed 1,000 campaigns. Finding: ..." Hard numbers are highly shareable because people want to comment with their own experience. Maps to the at-a-glance slide pattern.
+
+**Question-Based Discovery (Socratic):**
+Each slide poses a question that the next slide answers. The viewer arrives at the conclusion through guided reasoning rather than being told. "Significantly increases dwell time per slide" because viewers pause to think. The scenario teaser "WHAT DO YOU DO?" slide already uses this pattern -- extend it across more slides.
+
+**Tutorial / Step-by-Step:**
+Number each step with large, bold numbers (Step 1, Step 2...). Start with a "What You'll Need" slide. End with an actionable CTA. The explicit numbering ("1/7") creates psychological compulsion to complete the sequence.
+
 ### Slide-Level Principles
 
 **Hook slide (always slide 1):**
-The first slide is the only one that has to stop the scroll. Under 10 words. Bold visual. A provocative statement, surprising statistic, or direct challenge to the viewer. "Everyone thinks they know Stuxnet" outperforms "Stuxnet: A Case Study." If the first slide doesn't create curiosity, no one swipes.
+The first slide is the only one that has to stop the scroll. Under 10 words. Bold visual. A provocative statement, surprising statistic, or direct challenge to the viewer. "Everyone thinks they know Stuxnet" outperforms "Stuxnet: A Case Study." If the first slide doesn't create curiosity, no one swipes. A number + benefit hook ("5 Marketing Blindspots Costing You Customers") sets expectations and creates completion drive.
 
 **Content slides (middle):**
-Structure as a story: establish a problem, build tension across slides, reveal the payoff near the end. Each slide should raise a question the next slide answers. "Carousels that create curiosity have higher swipe-through to the last slide" -- this is the mechanism behind engagement rate. One idea per slide, anchored by one graphic.
+Structure over spontaneity -- the sequence of slides is deliberately engineered to maintain momentum. Each slide should raise a question the next slide answers. One slide, one idea. Never cram multiple points onto a single slide -- think of each as "a well-timed, impactful statement, not a condensed document." Clarity trumps complexity: ample whitespace, concise copy, clear visual hierarchy.
 
 **Last content slide before CTA:**
-Deliver the payoff -- the resolution, the insight, the "so what." This is the slide that earns the CTA click. It should feel like a conclusion, not just another content slide.
+Deliver the payoff -- the resolution, the insight, the "so what." This is the slide that earns the CTA click. It should feel like a conclusion, not just another content slide. End with a question that invites engagement: "Which of these mistakes are you making?" drives comments and shares.
 
 **CTA slide (always last):**
-Minimal. One action. No competing elements. The CTA should be obvious enough that someone skimming the final slide knows exactly what to do next.
+Minimal. One action. No competing elements. The CTA should be obvious enough that someone skimming the final slide knows exactly what to do next. An action-oriented CTA ("Try this framework for your next campaign") outperforms a passive one ("Learn more").
+
+### Quantify Everything
+
+Generic claims kill engagement. Specific numbers create credibility and discussion.
+
+- **Never:** "Improved revenue" → **Always:** "Revenue grew from $50k to $500k in 18 months"
+- **Never:** "LockBit is dangerous" → **Always:** "$91M in ransom revenue in a single year"
+- **Never:** "Faster encryption" → **Always:** "11 minutes to encrypt a full disk"
+
+This applies to every slide type: hook stats, before/after comparisons, ability descriptions, and impact claims. If a number exists, use it.
 
 ### Visual Consistency Rules
 
@@ -373,9 +405,13 @@ Empty space below content is a failure state. When recovered space appears (from
 
 Before uploading any carousel PDF, verify:
 
+- [ ] Carousel follows a named narrative framework (PSR, Before-After, Myth vs Reality, etc.)
 - [ ] Slide 1 hook is under 10 words and raises an immediate question
 - [ ] Every content slide has one dominant graphic element (not just styled text)
 - [ ] No slide has a text panel as the primary visual anchor
+- [ ] Content is vertically centered on every slide -- no top-heavy layouts with blank lower halves
+- [ ] One slide, one idea -- no slide tries to communicate two things at once
+- [ ] All claims are quantified with specific numbers, not generic statements
 - [ ] Color vocabulary is consistent: red = threat, green = defense, blue = info, orange = caution
 - [ ] Footer is present on every slide
 - [ ] Final content slide delivers a payoff and asks a question

--- a/scripts/generate-carousel.js
+++ b/scripts/generate-carousel.js
@@ -302,19 +302,18 @@ function renderExplainer(def) {
       ? `class="accent-line ${a.bulletClass || 'blue'} ${a.neonClass}"`
       : `class="accent-line ${a.bulletClass || 'blue'}"`;
 
-    const iconInlineStyle = a.neonClass
-      ? `color: ${a.colorVar};`
-      : `color: ${a.colorVar}; filter: drop-shadow(0 0 8px rgba(${a.shadowRgb},0.6)) drop-shadow(0 0 20px rgba(${a.shadowRgb},0.3));`;
+    // Use custom icon from YAML if provided, otherwise accent-derived
+    const slideIcon = slide.icon || a.icon;
 
     return `
 <div class="slide ${a.leftClass} ${bgClass}">
   <div class="slide-content">
-    <div class="slide-header">
-      <i class="${a.icon} slide-header-icon" style="${iconInlineStyle}"></i>
-      <div class="heading-md" style="color: ${accentColor};">${slide.heading || ''}</div>
+    <div style="text-align: center; margin-bottom: 20px;">
+      <i class="${slideIcon}" style="font-size: 160px; color: ${a.colorVar}; opacity: 0.2; filter: drop-shadow(0 0 24px rgba(${a.shadowRgb},0.6)) drop-shadow(0 0 60px rgba(${a.shadowRgb},0.25));"></i>
     </div>
+    <div class="heading-lg" style="color: ${accentColor}; margin-bottom: 12px;">${slide.heading || ''}</div>
     <div ${lineAttr}></div>
-    <div class="spacer-md"></div>
+    <div class="spacer-sm"></div>
     ${bullets}
   </div>
   <div class="slide-footer">

--- a/slides/manifest.json
+++ b/slides/manifest.json
@@ -2,7 +2,7 @@
   "slides": [],
   "meta": {
     "version": "1.0",
-    "last_updated": "2026-03-14",
+    "last_updated": "2026-04-16",
     "auto_generated": true
   }
 }

--- a/slides/scenarios/tier3-expert/winnti-biotech-rd-debrief.qmd
+++ b/slides/scenarios/tier3-expert/winnti-biotech-rd-debrief.qmd
@@ -17,6 +17,7 @@ metadata:
 .reveal section.mm-minimal[data-background-color] strong,
 .reveal section.mm-minimal[data-background-color] li,
 .reveal section.mm-minimal[data-background-color] .nonincremental p { color: white !important; }
+.reveal .mc-container { zoom: 0.50; margin: 0 auto; }
 </style>
 ```
 
@@ -150,36 +151,70 @@ Phase 5: Commitment -- 5 minutes. Don't let anyone skip the written step. Go aro
 
 ## Meet Your Adversary {data-visibility="player"}
 
-**Winnti -- The Silent Supply Chain Threat**
-
-::: {.columns}
-
-::: {.column width="60%"}
-**Type:** Backdoor / Nation-State
-
-**Primary Ability:** Supply Chain Delivery -- distributed through legitimate software update mechanisms
-
-**Special Attack:** Signed Kernel Rootkit -- uses stolen code-signing certificates; survives reboots, bypasses antivirus
-
-**Hidden Ability:** Passive Dormancy -- completely silent until activated by a specific network trigger; evades behavioural detection indefinitely
-
-**Weakness:** Certificate Revocation -- revoking the stolen signing certificate invalidates the kernel driver's trust chain
-:::
-
-::: {.column width="40%"}
-![Winnti](../../../im-handbook/resources/malmon-images/winnti.gif)
-:::
-
-:::
-
-**The correct response type for Winnti:** Patient and preservation-first. Winnti rewards teams that preserve evidence before eradicating -- rushing to isolate and wipe destroys the forensic artifacts that attribution depends on.
+```{=html}
+<style>
+.mc-container { display:block; width:480px; max-width:100%; }
+.mc-card { width:480px; min-width:480px; max-width:480px; border:3px solid #ED1C24; border-radius:15px; background:white; color:#212529; box-shadow:0 8px 16px rgba(0,0,0,.15); overflow:hidden; font-family:'Terminal',Courier,monospace; }
+.mc-header { background:#ED1C24; color:white; padding:1rem; text-align:center; }
+.mc-name { font-size:1.4rem; font-weight:bold; text-transform:uppercase; letter-spacing:1px; margin:0; }
+.mc-lenaean { font-size:0.9rem; font-style:italic; margin-top:0.2rem; opacity:0.9; }
+.mc-type-stars { display:flex; justify-content:space-between; align-items:center; margin-top:0.5rem; }
+.mc-type { background:rgba(255,255,255,.2); padding:0.3rem 0.8rem; border-radius:20px; font-size:0.9rem; font-weight:bold; text-transform:uppercase; }
+.mc-img { height:140px; background:#f8f9fa; display:flex; align-items:center; justify-content:center; margin:0.4rem 1rem; border-radius:8px; overflow:hidden; border:2px solid #dee2e6; }
+.mc-img img { max-width:100%; max-height:100%; object-fit:contain; }
+.mc-section-hdr { padding:0.8rem 1rem 0.3rem; border-bottom:2px solid #dee2e6; margin:0.8rem 1rem 0.5rem; }
+.mc-section-title { font-family:'Minecraft',-apple-system,sans-serif; font-size:0.9rem; font-weight:bold; color:#495057; text-transform:uppercase; letter-spacing:1px; margin:0; }
+.mc-ability { display:flex !important; align-items:flex-start; padding:0.6rem 1rem; gap:0.6rem; margin:0.3rem 1rem; border-radius:5px; border-left:4px solid #dee2e6; }
+.mc-ability.primary { background:#ffe6e6; border-left-color:#ED1C24; }
+.mc-ability.special  { background:#e6f3ff; border-left-color:#55A9FF; }
+.mc-ability.mc-dormant { background:#f0e6ff; border-left-color:#9b59b6; display:flex !important; }
+.mc-weakness { display:flex; align-items:flex-start; padding:0.6rem 1rem; gap:0.6rem; margin:0.3rem 1rem; border-radius:5px; border-left:4px solid #00C853; background:#e8f5e9; }
+.mc-icon { font-size:1.2rem; flex-shrink:0; margin-top:0.1rem; }
+.mc-content { flex:1; min-width:0; }
+.mc-aname { font-weight:bold; color:#495057; margin-bottom:0.2rem; font-size:0.9rem; }
+.mc-adesc { font-size:0.8rem; color:#6c757d; line-height:1.4; }
+</style>
+<div style="display:flex; gap:2.5rem; align-items:flex-start; width:100%;">
+  <div style="flex:1; font-family:sans-serif; padding-top:0.5rem;">
+    <p style="font-size:1.05rem; font-weight:bold; color:#212529; margin-bottom:0.8rem;">Patient and preservation-first.</p>
+    <p style="font-size:0.85rem; color:#495057; line-height:1.6; margin-bottom:1.2rem;">Preserve evidence before eradicating -- rushing to wipe destroys the forensic artifacts that attribution depends on.</p>
+    <div style="background:#e8f5e9; border-left:4px solid #00C853; border-radius:5px; padding:0.8rem 1rem;">
+      <div style="font-weight:bold; color:#495057; font-size:0.9rem; margin-bottom:0.3rem;">💎 Playing to the Weakness</div>
+      <div style="font-size:0.8rem; color:#6c757d; line-height:1.5;">Teams that isolated and preserved first played to <strong style="color:#495057;">Certificate Revocation</strong> -- the move that strips the kernel driver's trust chain. Teams that wiped immediately destroyed the artifact CFCS needed for cross-victim attribution.</div>
+    </div>
+  </div>
+  <div class="mc-container" style="flex:0 0 auto; margin:0;">
+    <div class="mc-card">
+      <div class="mc-header">
+        <div class="mc-name">Winnti</div>
+        <div class="mc-lenaean">Sinicus Furtivus Winntiius (Asia-Pacific 2011)</div>
+        <div class="mc-type-stars">
+          <div class="mc-type">Backdoor / Nation-State</div>
+          <div>⭐⭐⭐</div>
+        </div>
+      </div>
+      <div class="mc-img"><img src="../../../im-handbook/resources/malmon-images/winnti.gif" alt="Winnti"></div>
+      <div>
+        <div class="mc-section-hdr"><div class="mc-section-title">🔥 ABILITIES</div></div>
+        <div class="mc-ability primary"><div class="mc-icon">🔥</div><div class="mc-content"><div class="mc-aname">Supply Chain Delivery</div><div class="mc-adesc">Distributes through legitimate software update mechanisms -- granting initial access without triggering endpoint defences</div></div></div>
+        <div class="mc-ability special"><div class="mc-icon">⚡</div><div class="mc-content"><div class="mc-aname">Signed Kernel Rootkit</div><div class="mc-adesc">Stolen code-signing certificates install a kernel-mode driver that survives reboots and bypasses antivirus (+3 persistence &amp; evasion)</div></div></div>
+        <div class="mc-ability mc-dormant"><div class="mc-icon">🔮</div><div class="mc-content"><div class="mc-aname">Passive Dormancy</div><div class="mc-adesc">Completely silent until activated by a specific magic packet -- evades behavioural detection indefinitely</div></div></div>
+        <div class="mc-section-hdr"><div class="mc-section-title">💎 WEAKNESS</div></div>
+        <div class="mc-weakness"><div class="mc-icon">💎</div><div class="mc-content"><div class="mc-aname">Certificate Revocation</div><div class="mc-adesc">Revoking the stolen signing certificate invalidates the kernel driver's trust chain (-3 evasion)</div></div></div>
+      </div>
+    </div>
+  </div>
+</div>
+```
 
 ::: {.notes}
-This slide connects the scenario to the M&M malmon mechanics. Explain briefly: every scenario is built around a real malware family modelled as a creature. The "correct response type" concept comes from the type-effectiveness system -- some response strategies work better against certain malmon types.
+This slide connects the scenario to the M&M malmon mechanics. Every scenario is built around a real malware family modelled as a creature. The "correct response type" concept comes from the type-effectiveness system.
 
-For Winnti specifically: the passive, patient nature of the malmon rewards a patient, methodical response. Teams that isolate and preserve first (rather than rushing to eradicate) are playing to the malmon's weakness. Teams that wipe immediately are playing into its strength.
+In game terms: Certificate Revocation is the weakness that matters. The stolen signing certificate is what gives Winnti its +3 evasion advantage -- the kernel driver loads because the OS trusts the certificate. Teams that preserved the memory image and handed the kernel driver artifact to CFCS were triggering exactly that weakness. Teams that wiped the infected host first destroyed the only artifact that could activate it.
 
-This is also a good moment to mention that Winnti is a real APT group (APT41) with documented campaigns against life sciences companies -- the scenario is not hypothetical.
+Passive Dormancy is why this was hard: the backdoor sat completely silent until activated by a specific magic network packet. No behavioural alerts. Nothing for EDR to catch. The game rewarded teams who didn't treat silence as absence.
+
+Winnti is a real APT group (APT41) with documented campaigns against life sciences companies -- the scenario is not hypothetical.
 :::
 
 ## {data-visibility="player" data-background-color="#0033FF" .mm-minimal}

--- a/slides/scenarios/tier3-expert/winnti-biotech-rd-debrief.qmd
+++ b/slides/scenarios/tier3-expert/winnti-biotech-rd-debrief.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Debrief"
-subtitle: "Winnti: Biotech R&D Espionage"
+subtitle: "Biotech R&D Espionage"
 
 format:
   revealjs:

--- a/slides/scenarios/tier3-expert/winnti-biotech-rd-debrief.qmd
+++ b/slides/scenarios/tier3-expert/winnti-biotech-rd-debrief.qmd
@@ -11,17 +11,6 @@ metadata:
   mm-scenario-id: "winnti-biotech-rd-debrief"
 ---
 
-```{=html}
-<style>
-.reveal section.mm-minimal[data-background-color] p,
-.reveal section.mm-minimal[data-background-color] strong,
-.reveal section.mm-minimal[data-background-color] li,
-.reveal section.mm-minimal[data-background-color] .nonincremental p { color: white !important; }
-.reveal .mc-container { zoom: 0.50; margin: 0 auto; }
-</style>
-```
-
-
 ## {data-visibility="player" data-background-color="#0033FF" .mm-minimal}
 
 ::: {.nonincremental}
@@ -32,6 +21,85 @@ The Game is Over.
 
 ::: {.notes}
 Let the room settle. Pause. Don't rush into the first question.
+:::
+
+## Meet Your Adversary {data-visibility="player"}
+
+```{=html}
+<style>
+.reveal section.mm-minimal[data-background-color] p,
+.reveal section.mm-minimal[data-background-color] strong,
+.reveal section.mm-minimal[data-background-color] li,
+.reveal section.mm-minimal[data-background-color] .nonincremental p { color: white !important; }
+.reveal .mc-container { zoom: 0.50; }
+.mc-container { display:block; width:480px; max-width:100%; }
+.mc-card { width:480px; min-width:480px; max-width:480px; border:3px solid #ED1C24; border-radius:15px; background:white; color:#212529; box-shadow:0 8px 16px rgba(0,0,0,.15); overflow:hidden; font-family:'Terminal',Courier,monospace; }
+.mc-header { background:#ED1C24; color:white; padding:1rem; text-align:center; }
+.mc-name { font-size:1.4rem; font-weight:bold; text-transform:uppercase; letter-spacing:1px; margin:0; }
+.mc-lenaean { font-size:0.9rem; font-style:italic; margin-top:0.2rem; opacity:0.9; }
+.mc-type-stars { display:flex; justify-content:space-between; align-items:center; margin-top:0.5rem; }
+.mc-type { background:rgba(255,255,255,.2); padding:0.3rem 0.8rem; border-radius:20px; font-size:0.9rem; font-weight:bold; text-transform:uppercase; }
+.mc-img { height:140px; background:#f8f9fa; display:flex; align-items:center; justify-content:center; margin:0.4rem 1rem; border-radius:8px; overflow:hidden; border:2px solid #dee2e6; }
+.mc-img img { max-width:100%; max-height:100%; object-fit:contain; }
+.mc-section-hdr { padding:0.8rem 1rem 0.3rem; border-bottom:2px solid #dee2e6; margin:0.8rem 1rem 0.5rem; }
+.mc-section-title { font-family:'Minecraft',-apple-system,sans-serif; font-size:0.9rem; font-weight:bold; color:#495057; text-transform:uppercase; letter-spacing:1px; margin:0; }
+.mc-ability { display:flex !important; align-items:flex-start; padding:0.6rem 1rem; gap:0.6rem; margin:0.3rem 1rem; border-radius:5px; border-left:4px solid #dee2e6; }
+.mc-ability.primary { background:#ffe6e6; border-left-color:#ED1C24; }
+.mc-ability.special  { background:#e6f3ff; border-left-color:#55A9FF; }
+.mc-ability.mc-dormant { background:#f0e6ff; border-left-color:#9b59b6; display:flex !important; }
+.mc-weakness { display:flex; align-items:flex-start; padding:0.6rem 1rem; gap:0.6rem; margin:0.3rem 1rem; border-radius:5px; border-left:4px solid #00C853; background:#e8f5e9; }
+.mc-icon { font-size:1.2rem; flex-shrink:0; margin-top:0.1rem; }
+.mc-content { flex:1; min-width:0; }
+.mc-aname { font-weight:bold; color:#495057; margin-bottom:0.2rem; font-size:0.9rem; }
+.mc-adesc { font-size:0.8rem; color:#6c757d; line-height:1.4; }
+</style>
+```
+
+:::: {.columns}
+::: {.column width="38%"}
+
+**The correct response type:** Patient and preservation-first.
+
+Preserve evidence before eradicating -- rushing to wipe destroys the forensic artifacts that attribution depends on.
+
+:::
+::: {.column width="62%"}
+
+```{=html}
+<div class="mc-container" style="margin:0 auto;">
+  <div class="mc-card">
+    <div class="mc-header">
+      <div class="mc-name">Winnti</div>
+      <div class="mc-lenaean">Sinicus Furtivus Winntiius (Asia-Pacific 2011)</div>
+      <div class="mc-type-stars">
+        <div class="mc-type">Backdoor / Nation-State</div>
+        <div>⭐⭐⭐</div>
+      </div>
+    </div>
+    <div class="mc-img"><img src="../../../im-handbook/resources/malmon-images/winnti.gif" alt="Winnti"></div>
+    <div>
+      <div class="mc-section-hdr"><div class="mc-section-title">🔥 ABILITIES</div></div>
+      <div class="mc-ability primary"><div class="mc-icon">🔥</div><div class="mc-content"><div class="mc-aname">Supply Chain Delivery</div><div class="mc-adesc">Distributes through legitimate software update mechanisms -- granting initial access without triggering endpoint defences</div></div></div>
+      <div class="mc-ability special"><div class="mc-icon">⚡</div><div class="mc-content"><div class="mc-aname">Signed Kernel Rootkit</div><div class="mc-adesc">Stolen code-signing certificates install a kernel-mode driver that survives reboots and bypasses antivirus (+3 persistence &amp; evasion)</div></div></div>
+      <div class="mc-ability mc-dormant"><div class="mc-icon">🔮</div><div class="mc-content"><div class="mc-aname">Passive Dormancy</div><div class="mc-adesc">Completely silent until activated by a specific magic packet -- evades behavioural detection indefinitely</div></div></div>
+      <div class="mc-section-hdr"><div class="mc-section-title">💎 WEAKNESS</div></div>
+      <div class="mc-weakness"><div class="mc-icon">💎</div><div class="mc-content"><div class="mc-aname">Certificate Revocation</div><div class="mc-adesc">Revoking the stolen signing certificate invalidates the kernel driver's trust chain (-3 evasion)</div></div></div>
+    </div>
+  </div>
+</div>
+```
+
+:::
+::::
+
+::: {.notes}
+This slide connects the scenario to the M&M malmon mechanics. Every scenario is built around a real malware family modelled as a creature. The "correct response type" concept comes from the type-effectiveness system.
+
+In game terms: Certificate Revocation is Winnti's weakness. The stolen signing certificate is what gives the kernel driver its +3 evasion advantage -- the OS trusts it because the certificate says it should. Teams that preserved the memory image and handed the artifact to CFCS were directly triggering that weakness. Teams that wiped the infected host first destroyed the only thing that could activate it.
+
+Passive Dormancy is why this was hard to catch: the backdoor sat completely silent until activated by a specific magic network packet. No behavioural alerts, nothing for EDR to flag. The game rewarded teams who didn't treat silence as absence.
+
+Winnti is a real APT group (APT41) with documented campaigns against life sciences companies -- the scenario is not hypothetical.
 :::
 
 ## Round by Round {data-visibility="player"}
@@ -147,80 +215,6 @@ Then complete this sentence aloud: *"When [situation], I will [specific action].
 
 ::: {.notes}
 Phase 5: Commitment -- 5 minutes. Don't let anyone skip the written step. Go around the room: one "when/if... then I will" sentence each. Research: written implementation intentions produce d = 0.65 effect on follow-through vs verbal-only. Write the START items on the whiteboard -- that becomes the session's visible output.
-:::
-
-## Meet Your Adversary {data-visibility="player"}
-
-```{=html}
-<style>
-.mc-container { display:block; width:480px; max-width:100%; }
-.mc-card { width:480px; min-width:480px; max-width:480px; border:3px solid #ED1C24; border-radius:15px; background:white; color:#212529; box-shadow:0 8px 16px rgba(0,0,0,.15); overflow:hidden; font-family:'Terminal',Courier,monospace; }
-.mc-header { background:#ED1C24; color:white; padding:1rem; text-align:center; }
-.mc-name { font-size:1.4rem; font-weight:bold; text-transform:uppercase; letter-spacing:1px; margin:0; }
-.mc-lenaean { font-size:0.9rem; font-style:italic; margin-top:0.2rem; opacity:0.9; }
-.mc-type-stars { display:flex; justify-content:space-between; align-items:center; margin-top:0.5rem; }
-.mc-type { background:rgba(255,255,255,.2); padding:0.3rem 0.8rem; border-radius:20px; font-size:0.9rem; font-weight:bold; text-transform:uppercase; }
-.mc-img { height:140px; background:#f8f9fa; display:flex; align-items:center; justify-content:center; margin:0.4rem 1rem; border-radius:8px; overflow:hidden; border:2px solid #dee2e6; }
-.mc-img img { max-width:100%; max-height:100%; object-fit:contain; }
-.mc-section-hdr { padding:0.8rem 1rem 0.3rem; border-bottom:2px solid #dee2e6; margin:0.8rem 1rem 0.5rem; }
-.mc-section-title { font-family:'Minecraft',-apple-system,sans-serif; font-size:0.9rem; font-weight:bold; color:#495057; text-transform:uppercase; letter-spacing:1px; margin:0; }
-.mc-ability { display:flex !important; align-items:flex-start; padding:0.6rem 1rem; gap:0.6rem; margin:0.3rem 1rem; border-radius:5px; border-left:4px solid #dee2e6; }
-.mc-ability.primary { background:#ffe6e6; border-left-color:#ED1C24; }
-.mc-ability.special  { background:#e6f3ff; border-left-color:#55A9FF; }
-.mc-ability.mc-dormant { background:#f0e6ff; border-left-color:#9b59b6; display:flex !important; }
-.mc-weakness { display:flex; align-items:flex-start; padding:0.6rem 1rem; gap:0.6rem; margin:0.3rem 1rem; border-radius:5px; border-left:4px solid #00C853; background:#e8f5e9; }
-.mc-icon { font-size:1.2rem; flex-shrink:0; margin-top:0.1rem; }
-.mc-content { flex:1; min-width:0; }
-.mc-aname { font-weight:bold; color:#495057; margin-bottom:0.2rem; font-size:0.9rem; }
-.mc-adesc { font-size:0.8rem; color:#6c757d; line-height:1.4; }
-</style>
-```
-
-:::: {.columns}
-::: {.column width="38%"}
-
-**The correct response type:** Patient and preservation-first.
-
-Preserve evidence before eradicating -- rushing to wipe destroys the forensic artifacts that attribution depends on.
-
-:::
-::: {.column width="62%"}
-
-```{=html}
-<div class="mc-container" style="margin:0 auto;">
-  <div class="mc-card">
-    <div class="mc-header">
-      <div class="mc-name">Winnti</div>
-      <div class="mc-lenaean">Sinicus Furtivus Winntiius (Asia-Pacific 2011)</div>
-      <div class="mc-type-stars">
-        <div class="mc-type">Backdoor / Nation-State</div>
-        <div>⭐⭐⭐</div>
-      </div>
-    </div>
-    <div class="mc-img"><img src="../../../im-handbook/resources/malmon-images/winnti.gif" alt="Winnti"></div>
-    <div>
-      <div class="mc-section-hdr"><div class="mc-section-title">🔥 ABILITIES</div></div>
-      <div class="mc-ability primary"><div class="mc-icon">🔥</div><div class="mc-content"><div class="mc-aname">Supply Chain Delivery</div><div class="mc-adesc">Distributes through legitimate software update mechanisms -- granting initial access without triggering endpoint defences</div></div></div>
-      <div class="mc-ability special"><div class="mc-icon">⚡</div><div class="mc-content"><div class="mc-aname">Signed Kernel Rootkit</div><div class="mc-adesc">Stolen code-signing certificates install a kernel-mode driver that survives reboots and bypasses antivirus (+3 persistence &amp; evasion)</div></div></div>
-      <div class="mc-ability mc-dormant"><div class="mc-icon">🔮</div><div class="mc-content"><div class="mc-aname">Passive Dormancy</div><div class="mc-adesc">Completely silent until activated by a specific magic packet -- evades behavioural detection indefinitely</div></div></div>
-      <div class="mc-section-hdr"><div class="mc-section-title">💎 WEAKNESS</div></div>
-      <div class="mc-weakness"><div class="mc-icon">💎</div><div class="mc-content"><div class="mc-aname">Certificate Revocation</div><div class="mc-adesc">Revoking the stolen signing certificate invalidates the kernel driver's trust chain (-3 evasion)</div></div></div>
-    </div>
-  </div>
-</div>
-```
-
-:::
-::::
-
-::: {.notes}
-This slide connects the scenario to the M&M malmon mechanics. Every scenario is built around a real malware family modelled as a creature. The "correct response type" concept comes from the type-effectiveness system.
-
-In game terms: Certificate Revocation is Winnti's weakness. The stolen signing certificate is what gives the kernel driver its +3 evasion advantage -- the OS trusts it because the certificate says it should. Teams that preserved the memory image and handed the artifact to CFCS were directly triggering that weakness. Teams that wiped the infected host first destroyed the only thing that could activate it.
-
-Passive Dormancy is why this was hard to catch: the backdoor sat completely silent until activated by a specific magic network packet. No behavioural alerts, nothing for EDR to flag. The game rewarded teams who didn't treat silence as absence.
-
-Winnti is a real APT group (APT41) with documented campaigns against life sciences companies -- the scenario is not hypothetical.
 :::
 
 ## {data-visibility="player" data-background-color="#0033FF" .mm-minimal}

--- a/slides/scenarios/tier3-expert/winnti-biotech-rd-debrief.qmd
+++ b/slides/scenarios/tier3-expert/winnti-biotech-rd-debrief.qmd
@@ -11,6 +11,31 @@ metadata:
   mm-scenario-id: "winnti-biotech-rd-debrief"
 ---
 
+```{=html}
+<style>
+.reveal section.mm-minimal[data-background-color] p,
+.reveal section.mm-minimal[data-background-color] strong,
+.reveal section.mm-minimal[data-background-color] li,
+.reveal section.mm-minimal[data-background-color] .nonincremental p { color: white !important; }
+</style>
+```
+
+## {data-visibility="im-only"}
+
+**Structured Debrief Protocol -- Full Format (20--30 min)**
+
+| Phase | Time | Purpose | Research effect |
+|---|---|---|---|
+| 1. Event Recall | 5 min | Facts first -- what happened | AAR basis: d = 0.67--0.79 retention |
+| 2. Role Reflection | 5 min | One voice per role, surface feelings before analysis | Prevents emotional block on learning |
+| 3. Gap Analysis | 5--8 min | Where decisions diverged from ideal | Scenario-specific questions follow |
+| 4. Real-World Transfer | 5--7 min | Bridge game to actual workplace | Increases transfer probability |
+| 5. Commitment (written) | 5 min | When/if... then I will... | Written intentions: d = 0.65 goal attainment |
+
+::: {.notes}
+Full format. If time collapses unexpectedly: skip to "Your Commitment" and require written output -- Name the Moment, Name the Gap, Name the Action -- 5 minutes.
+:::
+
 ## {data-visibility="player" data-background-color="#0033FF" .mm-minimal}
 
 ::: {.nonincremental}
@@ -23,14 +48,37 @@ The Game is Over.
 Let the room settle. Pause. Don't rush into the first question.
 :::
 
-## Write It Down {data-visibility="player"}
+## Round by Round {data-visibility="player"}
 
-**Write down the one decision you most want to revisit.**
+"Let's reconstruct what just happened -- facts first, no analysis yet."
 
-30 seconds. In silence.
+::: {.nonincremental}
+
+- **Round 1:** What was your first indicator something was wrong?
+- **Round 2:** What changed your understanding of the incident?
+- **Rounds 3--4:** What drove your final response decisions?
+:::
 
 ::: {.notes}
-Give them the full 30 seconds. Don't fill the silence. People need time to shift from "game mode" to "reflection mode." The act of writing forces them to commit to a specific moment before the group discussion dilutes it.
+Phase 1: Event Recall -- 5 minutes. Keep this factual. "What happened?" not "What went wrong?" You're building a shared timeline before any evaluation begins. Teams often have different versions of events -- reconciling them is part of the learning.
+:::
+
+## Your Role's Perspective {data-visibility="player"}
+
+1 minute silent: *What did you see that other teams missed?*
+
+Then round-robin -- 30--60 seconds each:
+
+::: {.nonincremental}
+
+- **Alpha:** What evidence was most and least useful?
+- **Bravo:** What containment step did you want that never happened?
+- **Charlie:** What external pressure affected the technical response?
+- **IC:** Where did you have enough to decide -- and where did you hesitate?
+:::
+
+::: {.notes}
+Phase 2: Role Reflection -- 5 minutes. Enforce speak-once-before-twice: everyone shares once before anyone speaks a second time. Surface feelings here before the analytical work in Gap Analysis. Unacknowledged frustration or embarrassment blocks cognitive learning.
 :::
 
 ## Could This Happen Here? {data-visibility="player"}
@@ -73,6 +121,21 @@ Give them the full 30 seconds. Don't fill the silence. People need time to shift
 5 minutes. The mirror question. Every organisation has decommission backlogs. Every organisation has exceptions that were supposed to be temporary. Ask: "What process would surface this before an attacker does?" Actionable: audit legacy systems, review exception governance, close orphaned ITSM tickets. This question should be uncomfortable. Let it be.
 :::
 
+## Bridge to Your World {data-visibility="player"}
+
+"Everything we discussed happened in the game. Now make it real."
+
+::: {.nonincremental}
+
+- How does your organisation's actual IR process compare to what we just practiced?
+- Which gaps from this scenario exist in your real environment right now?
+- If you had to brief your CISO on one insight from this session, what would it be?
+:::
+
+::: {.notes}
+Phase 4: Real-World Transfer -- 5-7 minutes. Steer toward systemic gaps, not individual blame. "We should have isolated the machine sooner" is an outcome. "We don't have a clear escalation trigger for when to isolate" is a process gap -- and it's transferable to real incidents.
+:::
+
 ## Who Owns Fixing This? {data-visibility="player"}
 
 After each question: **"Who owns fixing this?"**
@@ -83,14 +146,21 @@ Not "the security team." Not "IT." A name. A person. A date.
 If this wasn't asked after each of the previous questions, ask it now as a catch-all. The point is accountability -- not blame, not delegation, but a named person who will follow up. If the room can't name someone, that's the finding.
 :::
 
-## One Thing {data-visibility="player"}
+## Your Commitment {data-visibility="player"}
 
-**"One thing I'll do differently."**
+Write it down. 2 minutes.
 
-One sentence. Go around the room.
+::: {.nonincremental}
+
+- **STOP** -- one thing you'll stop doing
+- **START** -- one thing you'll start doing
+- **CONTINUE** -- one thing that worked and you'll keep
+:::
+
+Then complete this sentence aloud: *"When [situation], I will [specific action]."*
 
 ::: {.notes}
-Go around the room. One sentence each. Don't let anyone pass. Don't let anyone give a speech. One sentence. The constraint is the point -- it forces prioritisation. Write them down on the whiteboard as people speak. This becomes the session's output.
+Phase 5: Commitment -- 5 minutes. Don't let anyone skip the written step. Go around the room: one "when/if... then I will" sentence each. Research: written implementation intentions produce d = 0.65 effect on follow-through vs verbal-only. Write the START items on the whiteboard -- that becomes the session's visible output.
 :::
 
 ## Meet Your Adversary {data-visibility="player"}

--- a/slides/scenarios/tier3-expert/winnti-biotech-rd-debrief.qmd
+++ b/slides/scenarios/tier3-expert/winnti-biotech-rd-debrief.qmd
@@ -20,21 +20,6 @@ metadata:
 </style>
 ```
 
-## {data-visibility="im-only"}
-
-**Structured Debrief Protocol -- Full Format (20--30 min)**
-
-| Phase | Time | Purpose | Research effect |
-|---|---|---|---|
-| 1. Event Recall | 5 min | Facts first -- what happened | AAR basis: d = 0.67--0.79 retention |
-| 2. Role Reflection | 5 min | One voice per role, surface feelings before analysis | Prevents emotional block on learning |
-| 3. Gap Analysis | 5--8 min | Where decisions diverged from ideal | Scenario-specific questions follow |
-| 4. Real-World Transfer | 5--7 min | Bridge game to actual workplace | Increases transfer probability |
-| 5. Commitment (written) | 5 min | When/if... then I will... | Written intentions: d = 0.65 goal attainment |
-
-::: {.notes}
-Full format. If time collapses unexpectedly: skip to "Your Commitment" and require written output -- Name the Moment, Name the Gap, Name the Action -- 5 minutes.
-:::
 
 ## {data-visibility="player" data-background-color="#0033FF" .mm-minimal}
 

--- a/slides/scenarios/tier3-expert/winnti-biotech-rd-debrief.qmd
+++ b/slides/scenarios/tier3-expert/winnti-biotech-rd-debrief.qmd
@@ -177,17 +177,17 @@ Phase 5: Commitment -- 5 minutes. Don't let anyone skip the written step. Go aro
 ```
 
 :::: {.columns}
-::: {.column width="48%"}
+::: {.column width="38%"}
 
 **The correct response type:** Patient and preservation-first.
 
 Preserve evidence before eradicating -- rushing to wipe destroys the forensic artifacts that attribution depends on.
 
 :::
-::: {.column width="52%"}
+::: {.column width="62%"}
 
 ```{=html}
-<div class="mc-container" style="margin:0;">
+<div class="mc-container" style="margin:0 auto;">
   <div class="mc-card">
     <div class="mc-header">
       <div class="mc-name">Winnti</div>

--- a/slides/scenarios/tier3-expert/winnti-biotech-rd-debrief.qmd
+++ b/slides/scenarios/tier3-expert/winnti-biotech-rd-debrief.qmd
@@ -174,45 +174,51 @@ Phase 5: Commitment -- 5 minutes. Don't let anyone skip the written step. Go aro
 .mc-aname { font-weight:bold; color:#495057; margin-bottom:0.2rem; font-size:0.9rem; }
 .mc-adesc { font-size:0.8rem; color:#6c757d; line-height:1.4; }
 </style>
-<div style="display:flex; gap:2.5rem; align-items:flex-start; width:100%;">
-  <div style="flex:1; font-family:sans-serif; padding-top:0.5rem;">
-    <p style="font-size:1.05rem; font-weight:bold; color:#212529; margin-bottom:0.8rem;">Patient and preservation-first.</p>
-    <p style="font-size:0.85rem; color:#495057; line-height:1.6; margin-bottom:1.2rem;">Preserve evidence before eradicating -- rushing to wipe destroys the forensic artifacts that attribution depends on.</p>
-    <div style="background:#e8f5e9; border-left:4px solid #00C853; border-radius:5px; padding:0.8rem 1rem;">
-      <div style="font-weight:bold; color:#495057; font-size:0.9rem; margin-bottom:0.3rem;">💎 Playing to the Weakness</div>
-      <div style="font-size:0.8rem; color:#6c757d; line-height:1.5;">Teams that isolated and preserved first played to <strong style="color:#495057;">Certificate Revocation</strong> -- the move that strips the kernel driver's trust chain. Teams that wiped immediately destroyed the artifact CFCS needed for cross-victim attribution.</div>
+```
+
+:::: {.columns}
+::: {.column width="48%"}
+
+**The correct response type:** Patient and preservation-first.
+
+Preserve evidence before eradicating -- rushing to wipe destroys the forensic artifacts that attribution depends on.
+
+:::
+::: {.column width="52%"}
+
+```{=html}
+<div class="mc-container" style="margin:0;">
+  <div class="mc-card">
+    <div class="mc-header">
+      <div class="mc-name">Winnti</div>
+      <div class="mc-lenaean">Sinicus Furtivus Winntiius (Asia-Pacific 2011)</div>
+      <div class="mc-type-stars">
+        <div class="mc-type">Backdoor / Nation-State</div>
+        <div>⭐⭐⭐</div>
+      </div>
     </div>
-  </div>
-  <div class="mc-container" style="flex:0 0 auto; margin:0;">
-    <div class="mc-card">
-      <div class="mc-header">
-        <div class="mc-name">Winnti</div>
-        <div class="mc-lenaean">Sinicus Furtivus Winntiius (Asia-Pacific 2011)</div>
-        <div class="mc-type-stars">
-          <div class="mc-type">Backdoor / Nation-State</div>
-          <div>⭐⭐⭐</div>
-        </div>
-      </div>
-      <div class="mc-img"><img src="../../../im-handbook/resources/malmon-images/winnti.gif" alt="Winnti"></div>
-      <div>
-        <div class="mc-section-hdr"><div class="mc-section-title">🔥 ABILITIES</div></div>
-        <div class="mc-ability primary"><div class="mc-icon">🔥</div><div class="mc-content"><div class="mc-aname">Supply Chain Delivery</div><div class="mc-adesc">Distributes through legitimate software update mechanisms -- granting initial access without triggering endpoint defences</div></div></div>
-        <div class="mc-ability special"><div class="mc-icon">⚡</div><div class="mc-content"><div class="mc-aname">Signed Kernel Rootkit</div><div class="mc-adesc">Stolen code-signing certificates install a kernel-mode driver that survives reboots and bypasses antivirus (+3 persistence &amp; evasion)</div></div></div>
-        <div class="mc-ability mc-dormant"><div class="mc-icon">🔮</div><div class="mc-content"><div class="mc-aname">Passive Dormancy</div><div class="mc-adesc">Completely silent until activated by a specific magic packet -- evades behavioural detection indefinitely</div></div></div>
-        <div class="mc-section-hdr"><div class="mc-section-title">💎 WEAKNESS</div></div>
-        <div class="mc-weakness"><div class="mc-icon">💎</div><div class="mc-content"><div class="mc-aname">Certificate Revocation</div><div class="mc-adesc">Revoking the stolen signing certificate invalidates the kernel driver's trust chain (-3 evasion)</div></div></div>
-      </div>
+    <div class="mc-img"><img src="../../../im-handbook/resources/malmon-images/winnti.gif" alt="Winnti"></div>
+    <div>
+      <div class="mc-section-hdr"><div class="mc-section-title">🔥 ABILITIES</div></div>
+      <div class="mc-ability primary"><div class="mc-icon">🔥</div><div class="mc-content"><div class="mc-aname">Supply Chain Delivery</div><div class="mc-adesc">Distributes through legitimate software update mechanisms -- granting initial access without triggering endpoint defences</div></div></div>
+      <div class="mc-ability special"><div class="mc-icon">⚡</div><div class="mc-content"><div class="mc-aname">Signed Kernel Rootkit</div><div class="mc-adesc">Stolen code-signing certificates install a kernel-mode driver that survives reboots and bypasses antivirus (+3 persistence &amp; evasion)</div></div></div>
+      <div class="mc-ability mc-dormant"><div class="mc-icon">🔮</div><div class="mc-content"><div class="mc-aname">Passive Dormancy</div><div class="mc-adesc">Completely silent until activated by a specific magic packet -- evades behavioural detection indefinitely</div></div></div>
+      <div class="mc-section-hdr"><div class="mc-section-title">💎 WEAKNESS</div></div>
+      <div class="mc-weakness"><div class="mc-icon">💎</div><div class="mc-content"><div class="mc-aname">Certificate Revocation</div><div class="mc-adesc">Revoking the stolen signing certificate invalidates the kernel driver's trust chain (-3 evasion)</div></div></div>
     </div>
   </div>
 </div>
 ```
 
+:::
+::::
+
 ::: {.notes}
 This slide connects the scenario to the M&M malmon mechanics. Every scenario is built around a real malware family modelled as a creature. The "correct response type" concept comes from the type-effectiveness system.
 
-In game terms: Certificate Revocation is the weakness that matters. The stolen signing certificate is what gives Winnti its +3 evasion advantage -- the kernel driver loads because the OS trusts the certificate. Teams that preserved the memory image and handed the kernel driver artifact to CFCS were triggering exactly that weakness. Teams that wiped the infected host first destroyed the only artifact that could activate it.
+In game terms: Certificate Revocation is Winnti's weakness. The stolen signing certificate is what gives the kernel driver its +3 evasion advantage -- the OS trusts it because the certificate says it should. Teams that preserved the memory image and handed the artifact to CFCS were directly triggering that weakness. Teams that wiped the infected host first destroyed the only thing that could activate it.
 
-Passive Dormancy is why this was hard: the backdoor sat completely silent until activated by a specific magic network packet. No behavioural alerts. Nothing for EDR to catch. The game rewarded teams who didn't treat silence as absence.
+Passive Dormancy is why this was hard to catch: the backdoor sat completely silent until activated by a specific magic network packet. No behavioural alerts, nothing for EDR to flag. The game rewarded teams who didn't treat silence as absence.
 
 Winnti is a real APT group (APT41) with documented campaigns against life sciences companies -- the scenario is not hypothetical.
 :::

--- a/slides/scenarios/tier3-expert/winnti-biotech-rd-intro.qmd
+++ b/slides/scenarios/tier3-expert/winnti-biotech-rd-intro.qmd
@@ -79,10 +79,12 @@ The key insight for players: information asymmetry is the mechanic, not a bug. T
 ## Your Teams {data-visibility="player"}
 
 ```{=html}
-<table style="width:100%;border-collapse:collapse;font-size:0.8em;">
-<tr style="background:transparent;"><td style="padding:16px 8px;border:none;"><strong>ALPHA</strong></td><td style="padding:16px 8px;border:none;">Forensics</td><td style="padding:16px 8px;border:none;">What happened on the systems. Processes, artefacts, evidence.</td></tr>
-<tr style="background:transparent;"><td style="padding:16px 8px;border:none;"><strong>BRAVO</strong></td><td style="padding:16px 8px;border:none;">Network &amp; Infrastructure</td><td style="padding:16px 8px;border:none;">How it moved through the network. Connections, access, traffic.</td></tr>
-<tr style="background:transparent;"><td style="padding:16px 8px;border:none;"><strong>CHARLIE</strong></td><td style="padding:16px 8px;border:none;">Threat Intel &amp; Recovery</td><td style="padding:16px 8px;border:none;">Who is behind it and how to respond. Attribution, scope, recovery.</td></tr>
+<table style="width:100%;border-collapse:collapse;font-size:0.85em;">
+<tr style="background:transparent;">
+  <td style="padding:16px 20px;border:none;vertical-align:top;width:33%;"><strong>ALPHA</strong><br>Forensics<br><br>What happened on the systems. Processes, artefacts, evidence.</td>
+  <td style="padding:16px 20px;border:none;vertical-align:top;width:33%;"><strong>BRAVO</strong><br>Network &amp; Infrastructure<br><br>How it moved through the network. Connections, access, traffic.</td>
+  <td style="padding:16px 20px;border:none;vertical-align:top;width:33%;"><strong>CHARLIE</strong><br>Threat Intel &amp; Recovery<br><br>Who is behind it and how to respond. Attribution, scope, recovery.</td>
+</tr>
 </table>
 ```
 

--- a/slides/scenarios/tier3-expert/winnti-biotech-rd-intro.qmd
+++ b/slides/scenarios/tier3-expert/winnti-biotech-rd-intro.qmd
@@ -11,6 +11,15 @@ metadata:
   mm-scenario-id: "winnti-biotech-rd-intro"
 ---
 
+```{=html}
+<style>
+.reveal section.mm-minimal[data-background-color] p,
+.reveal section.mm-minimal[data-background-color] strong,
+.reveal section.mm-minimal[data-background-color] li,
+.reveal section.mm-minimal[data-background-color] .nonincremental p { color: white !important; }
+</style>
+```
+
 ## Malware & Monsters {data-visibility="player"}
 
 **A Collaborative Cybersecurity Exercise**
@@ -21,10 +30,24 @@ Malware & Monsters is an **open-source** incident response training framework. Y
 There are no trick questions. There are no wrong answers.
 
 **There are decisions, consequences, and a debrief where the real learning happens.**
+
+malwareandmonsters.com
 :::
 
 ::: {.notes}
 30 seconds. Most players don't need a long framework introduction. They need to know: this is collaborative, there are no gotchas, and the debrief is where we connect it to real life.
+:::
+
+## This Version is Custom {data-visibility="player"}
+
+Today's scenario is a custom exercise built for this session.
+
+::: {.nonincremental}
+The full M&M framework -- including a visual guide and zero-prep scenarios you can run tomorrow -- is available free at **malwareandmonsters.com**
+:::
+
+::: {.notes}
+One slide. Point people to the site if they want to run their own session. Don't dwell -- this is context, not a sales pitch.
 :::
 
 ## Three Teams. One Incident. {data-visibility="player"}
@@ -123,9 +146,9 @@ Point at the physical whiteboard in the room. If it's not set up yet, set it up 
 
 ::: {.nonincremental}
 
-1. **Open your envelope** -- each team gets new evidence cards
+1. **Pick up your evidence cards** -- each team gets new cards
 2. **Analyse as a team** -- 8-12 minutes at your table
-3. **Team Lead briefs the IC** -- 60-90 seconds each, other teams listen
+3. **Team Lead briefs the IC** -- 60-90 seconds each, one at a time. Other teams do not listen in.
 4. **IC synthesises** -- connects the threads, updates the whiteboard
 5. **Next round** -- new envelopes, deeper evidence
 :::
@@ -141,8 +164,8 @@ Walk through these steps slowly. Most players will not have done this format bef
 ::: {.nonincremental}
 
 1. **Your evidence stays at your table.** Do not show cards to other teams.
-2. **When analysis time ends, the briefing starts.** No extensions.
-3. **Team Leads brief the IC. Not the other way round.**
+2. **When the facilitator calls time, analysis stops immediately and IC briefings begin.** No extensions.
+3. **Team Leads brief the IC one at a time. Other teams step away and do not listen in.**
 4. **The IC's call is the call.** Voice disagreement once, then commit.
 5. **You will not have all the answers.** That is fine. Neither does anyone else.
 :::
@@ -158,15 +181,15 @@ When the IC proposes a containment action:
 ::: {.nonincremental}
 
 1. **Which team owns this?** The IC assigns it.
-2. **How hard is it?** The team assesses difficulty.
+2. **How hard is it?** The facilitator decides difficulty and drives the storyline accordingly.
 3. **What could go wrong?** The team states the risk.
 4. **Roll.** Success, partial, or failure.
 :::
 
-**Helps your roll:** All teams briefed (+2) · Written rationale (+1) · Risk pre-identified (roll twice, take higher)
+**Helps your roll:** All teams briefed (+2) · Written rationale (+1) · Team named this risk before rolling: advantage (roll twice, take higher)
 
 ::: {.notes}
-One pass through is enough -- players do not need to memorise modifiers. The facilitator applies them during the session. Skip this slide if not using dice.
+One pass through is enough -- players do not need to memorise modifiers. The facilitator sets difficulty (Easy = 5+, Medium = 10+, Hard = 15+) and applies modifiers. Advantage = roll two d20s, keep the better result. It triggers only when the team explicitly named the specific risk *before* rolling -- not after the fact. Rewards careful risk articulation. Skip this slide if not using dice.
 :::
 
 ## BioGenix Solutions {data-visibility="player"}
@@ -214,14 +237,16 @@ This is the atmosphere-setter. Pause here. Let the room quiet down. This replace
 
 **You have 2 minutes.**
 
-The scenario begins when the envelopes are distributed.
+The scenario begins when the evidence cards are distributed.
 
 ::: {.notes}
-Breathing space before envelopes go out. Confirm IC has been briefed. Make sure the whiteboard is set up with CONTAINED / OPEN columns. When ready: distribute Round 1 envelopes.
+Breathing space before cards go out. Confirm IC has been briefed. Make sure the whiteboard is set up with CONTAINED / OPEN columns. When ready: distribute Round 1 evidence cards.
 :::
 
 ## {data-visibility="player" data-background-color="#0033FF" .mm-minimal}
 
+**Round 1 begins now.**
+
 ::: {.notes}
-Distribute Round 1 envelopes. Start timer. The game has begun.
+Distribute Round 1 evidence cards. Start timer. The game has begun.
 :::

--- a/slides/scenarios/tier3-expert/winnti-biotech-rd-intro.qmd
+++ b/slides/scenarios/tier3-expert/winnti-biotech-rd-intro.qmd
@@ -81,9 +81,19 @@ The key insight for players: information asymmetry is the mechanic, not a bug. T
 ```{=html}
 <table style="width:100%;border-collapse:collapse;font-size:0.85em;">
 <tr style="background:transparent;">
-  <td style="padding:16px 20px;border:none;vertical-align:top;width:33%;"><strong>ALPHA</strong><br>Forensics<br><br>What happened on the systems. Processes, artefacts, evidence.</td>
-  <td style="padding:16px 20px;border:none;vertical-align:top;width:33%;"><strong>BRAVO</strong><br>Network &amp; Infrastructure<br><br>How it moved through the network. Connections, access, traffic.</td>
-  <td style="padding:16px 20px;border:none;vertical-align:top;width:33%;"><strong>CHARLIE</strong><br>Threat Intel &amp; Recovery<br><br>Who is behind it and how to respond. Attribution, scope, recovery.</td>
+  <td style="padding:8px 20px;border:none;width:33%;"><strong>ALPHA</strong></td>
+  <td style="padding:8px 20px;border:none;width:33%;"><strong>BRAVO</strong></td>
+  <td style="padding:8px 20px;border:none;width:33%;"><strong>CHARLIE</strong></td>
+</tr>
+<tr style="background:transparent;">
+  <td style="padding:8px 20px;border:none;">Forensics</td>
+  <td style="padding:8px 20px;border:none;">Network &amp; Infrastructure</td>
+  <td style="padding:8px 20px;border:none;">Threat Intel &amp; Recovery</td>
+</tr>
+<tr style="background:transparent;">
+  <td style="padding:8px 20px;border:none;">What happened on the systems. Processes, artefacts, evidence.</td>
+  <td style="padding:8px 20px;border:none;">How it moved through the network. Connections, access, traffic.</td>
+  <td style="padding:8px 20px;border:none;">Who is behind it and how to respond. Attribution, scope, recovery.</td>
 </tr>
 </table>
 ```

--- a/slides/scenarios/tier3-expert/winnti-biotech-rd-intro.qmd
+++ b/slides/scenarios/tier3-expert/winnti-biotech-rd-intro.qmd
@@ -17,6 +17,18 @@ metadata:
 .reveal section.mm-minimal[data-background-color] strong,
 .reveal section.mm-minimal[data-background-color] li,
 .reveal section.mm-minimal[data-background-color] .nonincremental p { color: white !important; }
+.reveal .slides .no-border-table table,
+.reveal .slides .no-border-table th,
+.reveal .slides .no-border-table td,
+.reveal .slides .no-border-table tr,
+.reveal .slides .no-border-table tbody tr {
+  border: none !important;
+  background: transparent !important;
+}
+.reveal .slides .no-border-table table {
+  font-size: 0.7em;
+  width: 100%;
+}
 </style>
 ```
 
@@ -66,30 +78,13 @@ The key insight for players: information asymmetry is the mechanic, not a bug. T
 
 ## Your Teams {data-visibility="player"}
 
-::: {.columns}
-
-::: {.column width="33%"}
-**ALPHA**
-Forensics
-
-What happened on the systems. Processes, artefacts, evidence.
-:::
-
-::: {.column width="33%"}
-**BRAVO**
-Network & Infrastructure
-
-How it moved through the network. Connections, access, traffic.
-:::
-
-::: {.column width="33%"}
-**CHARLIE**
-Threat Intel & Recovery
-
-Who is behind it and how to respond. Attribution, scope, recovery.
-:::
-
-:::
+```{=html}
+<table style="width:100%;border-collapse:collapse;font-size:0.8em;">
+<tr style="background:transparent;"><td style="padding:16px 8px;border:none;"><strong>ALPHA</strong></td><td style="padding:16px 8px;border:none;">Forensics</td><td style="padding:16px 8px;border:none;">What happened on the systems. Processes, artefacts, evidence.</td></tr>
+<tr style="background:transparent;"><td style="padding:16px 8px;border:none;"><strong>BRAVO</strong></td><td style="padding:16px 8px;border:none;">Network &amp; Infrastructure</td><td style="padding:16px 8px;border:none;">How it moved through the network. Connections, access, traffic.</td></tr>
+<tr style="background:transparent;"><td style="padding:16px 8px;border:none;"><strong>CHARLIE</strong></td><td style="padding:16px 8px;border:none;">Threat Intel &amp; Recovery</td><td style="padding:16px 8px;border:none;">Who is behind it and how to respond. Attribution, scope, recovery.</td></tr>
+</table>
+```
 
 ::: {.notes}
 Each team's lens is genuinely different -- not a difficulty tier. Alpha is not "harder" than Charlie. They are different angles on the same incident.
@@ -103,13 +98,12 @@ Each team's lens is genuinely different -- not a difficulty tier. Alpha is not "
 
 - **IC #1** manages the first half -- Rounds 1 and 2
 - **IC #2** takes over mid-session after a structured handover
-- IC #2 will leave the room shortly and return for the handover
 :::
 
 The IC does not join a team. The IC **listens**, **connects** the threads, and **decides** when teams disagree.
 
 ::: {.notes}
-Brief the ICs privately before this slide if not already done. Key message: the IC is the listener and synthesiser, not the technical lead. IC #2 leaves after this briefing.
+Brief the ICs privately before this slide if not already done. Key message: the IC is the listener and synthesiser, not the technical lead.
 :::
 
 ## The Whiteboard {data-visibility="player"}
@@ -148,12 +142,12 @@ Point at the physical whiteboard in the room. If it's not set up yet, set it up 
 
 1. **Pick up your evidence cards** -- each team gets new cards
 2. **Analyse as a team** -- 8-12 minutes at your table
-3. **Team Lead briefs the IC** -- 60-90 seconds each, one at a time. Other teams do not listen in.
+3. **Team Lead briefs the IC** -- 60-90 seconds each, one at a time.
 4. **IC synthesises** -- connects the threads, updates the whiteboard
 5. **Next round** -- new envelopes, deeper evidence
 :::
 
-**If your team reaches a dead end or wants to go deeper: ask the facilitator.**
+**If you need more information or context at any point, ask the facilitator.**
 
 ::: {.notes}
 Walk through these steps slowly. Most players will not have done this format before. The "ask the facilitator" line is important -- without it, players will not know they can ask, and the facilitator has no natural opening to release supplemental information.
@@ -165,7 +159,7 @@ Walk through these steps slowly. Most players will not have done this format bef
 
 1. **Your evidence stays at your table.** Do not show cards to other teams.
 2. **When the facilitator calls time, analysis stops immediately and IC briefings begin.** No extensions.
-3. **Team Leads brief the IC one at a time. Other teams step away and do not listen in.**
+3. **Team Leads brief the IC one at a time.**
 4. **The IC's call is the call.** Voice disagreement once, then commit.
 5. **You will not have all the answers.** That is fine. Neither does anyone else.
 :::
@@ -185,6 +179,8 @@ When the IC proposes a containment action:
 3. **What could go wrong?** The team states the risk.
 4. **Roll.** Success, partial, or failure.
 :::
+
+**Difficulty:** Easy 5+ · Medium 10+ · Hard 15+ (d20)
 
 **Helps your roll:** All teams briefed (+2) · Written rationale (+1) · Team named this risk before rolling: advantage (roll twice, take higher)
 

--- a/slides/scenarios/tier3-expert/winnti-biotech-rd-intro.qmd
+++ b/slides/scenarios/tier3-expert/winnti-biotech-rd-intro.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Malware & Monsters"
-subtitle: "Winnti: Biotech R&D Espionage"
+subtitle: "Biotech R&D Espionage"
 
 format:
   revealjs:


### PR DESCRIPTION
## Summary

- Winnti intro slides: frameless 3-row teams table, cleaned wording (removed IC#2 departure line, removed 'other teams' references), added Easy/Medium/Hard dice thresholds, removed malmon name from subtitle
- Winnti debrief slides: removed malmon name from subtitle, deleted IM-only protocol table slide, removed ghost blank slide, added Winnti malmon card (header through weakness) in a two-column layout with Meet Your Adversary moved to immediately follow the opening blue slide
- LinkedIn carousel templates and docs updated with narrative frameworks

## Test plan

- [ ] Verify intro slides render correctly at preview site
- [ ] Verify debrief: slide 1 = title, slide 2 = Game is Over, slide 3 = Meet Your Adversary with card on right
- [ ] Verify no regressions on other slide decks

🤖 Generated with [Claude Code](https://claude.com/claude-code)