### PR TITLE
docs(workshops): DEFCON 2026 syllabus draft

### DIFF
--- a/docs/workshops/defcon-2026-syllabus.md
+++ b/docs/workshops/defcon-2026-syllabus.md
@@ -1,0 +1,489 @@
+---
+title: "DEFCON 2026 Workshop Syllabus: Malware & Monsters"
+subtitle: "4-hour workshop — player to designer arc"
+date: "2026-04-20"
+author: "Chris (TrustedSec) and Kai"
+---
+
+# DEFCON 2026 Workshop Syllabus: Malware & Monsters
+
+
+> **Format:** 4-hour workshop (240 minutes)
+> **Facilitators:** 3 minimum (1 lead + 2 table IMs)
+> **Attendees:** 15-40 (designed to scale)
+
+---
+
+## Design Philosophy
+
+This syllabus was built from three independent analyses:
+
+1. **First principles decomposition** of what makes conference workshops valuable
+2. **Research** on professional workshop design, DEFCON logistics, and open-source contributor sprints (Kubernetes, scikit-learn models)
+3. **Multi-perspective debate** (game designer, workshop facilitator, OSS maintainer, DEFCON veteran)
+
+### The Core Insight
+
+The original concept framed the workshop as two halves: "play the game" then "contribute to the project." Every analysis converged on the same correction: **these aren't two activities — they're one arc.** The attendee's journey is **player to designer**. Every structural choice should accelerate that identity transition.
+
+A workshop that feels like "fun game" followed by "homework" will bleed attendees by hour 3. A workshop that feels like a single escalating experience — where contribution is the natural climax of play — keeps the room full and produces better output.
+
+### Seven Principles
+
+1. **Offline-first.** Everything works with zero network. Digital is a bonus path.
+2. **Paper-first contributions.** Templates, pens, printed cards. Facilitators digitize and PR post-workshop.
+3. **Play-dominant.** The game is the value proposition. Contribution earns its time by building on play momentum.
+4. **One continuous arc.** No phase change. Dissection bridges play into creation seamlessly.
+5. **Structured playtesting feedback is the primary contribution.** 40 simultaneous playtest sessions is data you can't buy. Scenario creation is the advanced bonus path.
+6. **Energy management through competition.** Hour 3 gets a high-energy showdown, not a lecture.
+7. **Pairs over individuals.** Social momentum from play carries into collaborative creation.
+
+---
+
+## Visual Timeline
+
+```
+TIME    MOVEMENT                         ENERGY     MODE
+─────────────────────────────────────────────────────────────
+0:00    ┌─ ARRIVAL & HOOK ──────────┐    ████░░░    Settling
+0:15    │  Scenario briefing         │    ██████░    Rising
+        └────────────────────────────┘
+0:20    ┌─ IMMERSION ───────────────┐    ████████    Peak
+        │  Full M&M scenario play    │    ████████    Sustained
+        │  Tables of 4-5, 1 IM each │    ███████░    Engaged
+1:40    └────────────────────────────┘
+1:40    ┌─ BREAK + GALLERY WALK ────┐    ████░░░░    Recovery
+1:55    └────────────────────────────┘
+1:55    ┌─ DISSECTION ─────────────┐     ██████░░    Reflective
+        │  Design-lens debrief      │    ███████░    Rising
+2:25    └────────────────────────────┘
+2:25    ┌─ CREATION ───────────────┐     ████████    Active
+        │  Pairs create on paper    │    ███████░    Sustained
+3:15    └────────────────────────────┘
+3:15    ┌─ SHOWDOWN ───────────────┐     ████████    Peak
+        │  Table vs table playtest  │    █████████   Climax
+3:45    └────────────────────────────┘
+3:45    ┌─ SHIP & CELEBRATE ───────┐     ███████░    Warm
+        │  Wall of contributions    │    ██████░░    Closing
+4:00    └────────────────────────────┘
+─────────────────────────────────────────────────────────────
+```
+
+---
+
+## Detailed Syllabus
+
+### Movement 1: Arrival & Hook (0:00 - 0:20)
+
+**Goal:** Every attendee seated, grouped, and excited within 20 minutes. Late arrivals can join up to 0:30.
+
+| Time | Activity | Who | Notes |
+|------|----------|-----|-------|
+| 0:00-0:10 | **Doors open.** Prereqs displayed on screen (none beyond "sit down"). Tables pre-set with dice, tent cards, scenario packets, pens, and a printed copy of the **Visual Guide** per table. Attendees self-seat at tables of 4-5. | All facilitators greeting | Play ambient music. No slides deck, no "please wait." Early arrivals can skim the Visual Guide (8 pages, covers everything they need). |
+| 0:10-0:15 | **The Hook.** Lead facilitator, 3-minute pitch. "In the next 80 minutes, your table is going to handle a live cyber incident. Ransomware is spreading through a hospital during flu season. You don't need to know the rules. You need to know your role. Your IM will handle the rest." | Lead facilitator | This is a STORY pitch, not a rules explanation. Create urgency. The scenario hook is the workshop hook. |
+| 0:15-0:20 | **Role selection & character intro.** IMs use the **Role Distributor** tool (works on any phone — enter headcount, tap Distribute). 4 core roles for first-play: Detective, Protector, Tracker, Communicator. Each player takes their tent card and places it facing outward. 30 seconds per person: introduce yourself in-character. "I'm the Detective. I see patterns others miss, and I haven't slept since Tuesday." | Table IMs | Crisis Manager and Threat Hunter are advanced roles — reserve for experienced tables or 5+ players. The Visual Guide explicitly recommends 4 core roles for first sessions. |
+
+**Facilitator notes:**
+
+- Tables pre-assigned (if possible)
+- Late arrivals through 0:30: seat at tables with open chairs, hand them a tent card, IM catches them up in-character ("You just got pulled off another project")
+- After 0:30: observers welcome, no new players mid-scenario
+
+**Materials needed:**
+
+- Pre-set tables: 5 chairs, 1-2 d20 dice, 4 printed tent cards (fold A4 landscape, role name faces outward, modifiers face player), scenario packet, pens, scratch paper
+- 1x printed **Visual Guide** per table (8 pages, print from `im-handbook/resources/practical-tools/visual-guide.html`) — this IS the player onboarding document
+- 1x printed **Players Quick Start** per player (1 page, from `players-handbook/resources/players-quick-start.html`)
+- Screen showing: "Sit anywhere. Grab dice. Your incident starts in [countdown]."
+
+---
+
+### Movement 2: Immersion — Play M&M (0:20 - 1:40)
+
+**Goal:** Every attendee experiences a complete, satisfying M&M scenario arc. They feel what good IR role play feels like.
+
+| Time | Activity | Who | Notes |
+|------|----------|-----|-------|
+| 0:20-0:25 | **Scenario launch.** IM reads the hook aloud. Sets the scene: organization, situation, first indicators of compromise. | Table IMs | Use the scenario card verbatim. This is a performance moment. |
+| 0:25-0:50 | **Discovery Round.** Players investigate. What malmon is this? What systems are affected? IMs use question-driven facilitation — never lecture, always ask. | Table IMs | Each player gets 2 actions. Collaborative bonus for teamwork. |
+| 0:50-1:10 | **Investigation Round.** Scope expands. Evidence cards revealed. Pressure mounts — NPC calls from the CEO, patient safety concerns, regulatory deadline. Evolution trigger if team is slow. | Table IMs | This is peak engagement. Let it breathe. Don't rush. |
+| 1:10-1:35 | **Response Round.** Containment strategy. Type effectiveness matters. Team coordinates their specialties. Resolution. | Table IMs | Give tables agency. Multiple valid endings. |
+| 1:35-1:40 | **Moment of truth.** IM reveals the real malware family behind their Malmon. 60-second "here's what really happened" — the actual incident this scenario was based on. | Table IMs | This is the "oh wow" moment — connecting game to reality. |
+
+**Scenario selection rationale:**
+
+| Candidate | Pros | Cons | Verdict |
+|-----------|------|------|---------|
+| **GaboonGrabber** | Beginner-friendly, phishing entry | Too simple for DEFCON's technical audience | Pass |
+| **FakeBat** | Contemporary, good pacing, we've played it | Mid-tier difficulty, good loader tactics | Backup |
+| **WannaCry** | Name recognition, dramatic spread mechanic | Historical — audience may know the story | Pass |
+| **LockBit** | Contemporary, RaaS model, double extortion, high drama | Complex — needs confident IMs | **Recommended** |
+| **Raspberry Robin** | USB propagation, physical-digital convergence | Less name recognition | Good alternative |
+
+**Recommendation: LockBit Hospital Emergency (US variant: Cedar Valley Medical Center).** DEFCON audience respects sophistication. The RaaS business model creates interesting role dynamics (Communicator handles ransom negotiation and disclosure, Detective traces lateral movement, Protector contains spread, Tracker monitors C2 beaconing). Hospital setting creates moral stakes — patient safety vs. operational decisions.
+
+**Why this specific variant:** LockBit Hospital Emergency has the most complete material set in the entire repo:
+
+- Full scenario card with 4 NPCs, secrets, and staged villain plan
+- Planning document with round-by-round pacing guidance (`im-handbook/resources/scenario-planning-docs/ransomware-advanced/`)
+- **Large-group facilitator guide** with 21 tiered evidence artifacts across 3 teams (Alpha/Forensics, Bravo/Network, Charlie/Business Impact) — explicitly designed as "the reference scenario for first large group sessions"
+- Regional variants (US + Denmark) if international facilitators prefer
+- Evidence handouts (Handout A: initial access evidence, Handout B+: deep analysis)
+
+If IMs aren't confident with LockBit complexity, fall back to FakeBat — one of only two zero-prep, fully-scripted onboarding scenarios in the IM Handbook, with every NPC line, clue, and resolution written out.
+
+**Session format:** Full Game format (3 rounds, 2 actions/player, open investigation, creative response) adapted to 75 minutes. This is tighter than the standard 120-140 min Full Game. The Visual Guide's "Breaking the Rules" section gives explicit permission: "Cut to Round 3 if time is short — pick a decision point and jump straight to containment and response." IMs should pre-read pacing notes and compress Investigation if tables are slow.
+
+**Facilitator notes:**
+
+- All 3 facilitators run tables during Immersion. Lead facilitator takes the largest or most experienced table.
+- If 4+ tables needed (25+ attendees), recruit 1-2 experienced M&M players as volunteer IMs — brief them 30 min before doors open.
+- IMs should have the **planning document** for their scenario, not just the scenario card. The planning doc has round-by-round pacing guidance.
+- For 25+ attendees, consider using the **large-group format** directly: 3 teams (Alpha, Bravo, Charlie) each with their own IM, playing the same scenario with different evidence streams. This IS what the LockBit Hospital Emergency large-group guide was built for.
+
+---
+
+### Movement 3: Break + Gallery Walk (1:40 - 1:55)
+
+**Goal:** Physical reset. Attendees see other tables' experiences. Seeds the "what would I do differently" mindset.
+
+| Time | Activity | Who | Notes |
+|------|----------|-----|-------|
+| 1:40-1:50 | **Break.** Restrooms, water, stretch. Each table's IM writes 3 things on a large notecard: (1) their malmon, (2) their outcome, (3) "the moment everything went sideways." Posts it on the wall. | Everyone | Physical movement is mandatory. Don't skip. |
+| 1:50-1:55 | **Gallery walk.** Attendees browse other tables' cards. See different outcomes from the same (or different) scenarios. | Everyone | This naturally generates "we should have..." and "I would have..." conversation. That's the bridge to creation. |
+
+**Materials needed:**
+
+- Large notecards or half-sheets (pre-placed at tables)
+- Markers (thick, readable from 5 feet)
+- Wall space or easels for posting
+- Optional: sticky dots for "most dramatic moment" voting
+
+---
+
+### Movement 4: Dissection — Design-Lens Debrief (1:55 - 2:25)
+
+**Goal:** Shift attendees from player to designer. They see the scaffolding behind the experience they just had.
+
+This is the **highest-leverage 30 minutes** in the entire workshop. Skip it and you get a fun game session followed by a confusing creation phase. Nail it and contribution feels inevitable.
+
+| Time | Activity | Who | Notes |
+|------|----------|-----|-------|
+| 1:55-2:05 | **Whole-room debrief.** Lead facilitator runs the **AAR-backed Structured Debrief Protocol** (Issue #201 — completed, repo at `im-handbook/resources/practical-tools/facilitation-guides/debrief-protocol.qmd`). Use the **short format (5 min):** (1) Name the moment — "What was the single decision that changed everything?" (2) Name the gap — "What did you wish you knew sooner?" (3) Name the action — "What would you do differently in a real incident?" Then 5 min open discussion across tables. Not "how did you feel" — what would you DO. | Lead facilitator | The debrief protocol has session-level adaptations for beginner/intermediate/advanced and a facilitator toolkit for difficult scenarios (dominant players, disengaged tables). Use it. |
+| 2:05-2:15 | **Anatomy of a scenario card.** Lead facilitator displays the LockBit Hospital Emergency scenario card on screen. Walks through each element: **Organization** (who and what scale), **Hook** (why now), **Pressure** (stakes), **NPCs** (4 characters with motivations/conflicts), **Secrets** (what the org is hiding), **Villain Plan** (staged progression), **Adaptation Notes** (complexity dials). "You just played this. Here's what was on my cheat sheet. Remember when the CEO called about the ransom deadline? That was this NPC. The reason segmentation was incomplete? That was this Secret." | Lead facilitator | Use the actual scenario they just played. Demystification is the bridge to creation. Show how each field created a specific moment they remember. |
+| 2:15-2:25 | **The contribution menu.** Lead facilitator presents two paths: (1) Structured Playtesting Feedback — "you just generated incredible data, let's capture it properly" and (2) Scenario Creation — "design a new scenario for a malmon of your choice." Templates distributed. | Lead facilitator + table IMs distributing templates | Paper templates pre-printed. Both paths have fill-in-the-blank structure. |
+
+**The two contribution paths:**
+
+**Path A: Structured Playtesting Feedback (default, recommended for most)**
+> "You just playtested M&M with fresh eyes. That perspective is gold. This form captures what worked, what confused you, where the rules needed house-ruling, and what you'd change."
+
+- 1-page structured feedback form (pre-printed)
+- Sections: Scenario rating, Moment that worked best, Rule that confused us, House-rule we invented, What we'd change, Role balance assessment
+- Completed in pairs (2 people per form, one writes, one adds)
+- **Why this is valuable:** 15-20 simultaneous playtest feedback forms is data no project gets outside a formal playtest program. This is a genuine, high-value contribution.
+
+**Path B: Scenario Creation (advanced, for tables that want creative challenge)**
+> "Design a new scenario for any malmon in the game. Use this template — it's the same structure you just played through."
+
+- 2-page scenario card template (pre-printed, mirroring actual repo format)
+- Fill-in-the-blank: Organization (name + scale + industry), Hook (why now?), Pressure (what's at stake?), NPCs (4, with roles and motivations/conflicts), Secrets (what the organization is hiding — 3 items), Villain Plan (3-stage progression), Adaptation Notes (what to dial up/down for difficulty)
+- Pick any malmon from the game — the malmon card on their table tells them the threat's abilities and weaknesses
+- Completed in pairs or table groups
+- Validation rubric on the back: Does it have 2+ decision points? Is the threat actor realistic? Can it resolve in 30 min of play?
+
+**Facilitator notes:**
+
+- Don't oversell either path. "Both are real contributions. Pick what sounds fun."
+- Tables can split — 2 pairs doing feedback, 1 pair doing scenario creation
+- IMs float between tables during creation, answering questions, providing examples
+
+---
+
+### Movement 5: Creation Sprint (2:25 - 3:15)
+
+**Goal:** Pairs create content on paper. The room is active, social, productive.
+
+| Time | Activity | Who | Notes |
+|------|----------|-----|-------|
+| 2:25-2:35 | **Pair up and start.** Tables split into pairs. Pick a path. Start filling in templates. IMs circulate. | Table IMs circulating | Don't over-explain. The templates are designed to be self-guiding. |
+| 2:35-2:55 | **Deep work.** Pairs are writing, discussing, debating. IMs answer questions, provide examples, validate ideas. "That's a great NPC conflict — a CISO who knows about the vulnerability but didn't patch because of the board meeting." | Table IMs | This is the quietest 20 minutes. That's okay. Creative work needs focus. |
+| 2:55-3:05 | **Cross-pollination.** Pairs swap templates with another pair at their table for 5-minute review. "Read theirs. Write one thing that's great and one thing that needs more detail." | Self-directed, IMs facilitate | Peer feedback is both a quality gate and an energy boost. |
+| 3:05-3:15 | **Polish.** Pairs incorporate feedback, finalize their templates. | Pairs | IMs collect "we're done" submissions to the Contribution Wall. |
+
+**Facilitator notes:**
+
+- (if possible) Background music helps during deep work (low ambient, not distracting)
+- IMs should spend most time with scenario creation pairs (harder task, more questions)
+- Feedback forms are faster — those pairs will finish by 2:50. Give them a bonus task: "Pick a scenario card from another malmon and mark it up with suggestions."
+- The **Contribution Wall** is a physical board where completed forms/cards get pinned. It fills visibly throughout this movement.
+
+---
+
+### Movement 6: Showdown (3:15 - 3:45)
+
+**Goal:** Competitive, high-energy climax. Tables playtest each other's scenario creations. This is the "hour 3 energy injection."
+
+| Time | Activity | Who | Notes |
+|------|----------|-----|-------|
+| 3:15-3:20 | **Showdown rules.** Lead facilitator: "Two tables with scenario cards are going to swap and speed-run each other's scenario. 15 minutes. The table that creates a more playable scenario wins. Everyone else: you're the judges." | Lead facilitator | If fewer than 2 tables created scenarios, adapt: one table playtests the best scenario while others observe and score. |
+| 3:20-3:35 | **Speed playtest.** Two tables play each other's scenarios in compressed format (Discovery round only, 15 minutes). Rest of room observes, fills out "judge cards." | Competing tables + judges | This is loud, fun, competitive. The game mechanics do the work. |
+| 3:35-3:45 | **Judging + awards.** Crowd votes: most playable scenario, most creative hook, best NPC. Lead facilitator announces winners. | Lead facilitator | Physical prizes if available (M&M stickers, custom dice, contributor badge). If no scenario pairs: award for best playtesting feedback ("most actionable insight"). |
+
+**Adaptation for smaller groups (< 20):**
+
+- Skip the competitive framing. Instead: one pair's scenario gets playtested by the whole room in a "world premiere" format. The creators watch their scenario being played for the first time. This is magical even without competition.
+
+**Adaptation if no one chose scenario creation:**
+
+- Run a "feedback highlight reel" instead. Each table shares their most surprising finding. Lead facilitator curates the top 5 insights live. "These are going directly into the next version."
+
+---
+
+### Movement 7: Ship & Celebrate (3:45 - 4:00)
+
+**Goal:** Clean close. Every attendee knows what they contributed and how to stay connected.
+
+| Time | Activity | Who | Notes |
+|------|----------|-----|-------|
+| 3:45-3:50 | **The Wall.** Lead facilitator walks the Contribution Wall. "Look at what this room built in 2 hours. [X] playtesting insights. [Y] new scenarios. This is going into the project." Reads 2-3 highlights. | Lead facilitator | This is the emotional peak of the close. Make it genuine. |
+| 3:50-3:55 | **What happens next.** "Every contribution on this wall gets digitized and attributed. Your name goes in the git history. If you want to keep going: Discord invite [QR code on screen]. Next playtest session: [date if known]." QR code for Discord, project URL. | Lead facilitator | QR code, not URL. Nobody types URLs at DEFCON. |
+| 3:55-4:00 | **Thank you + open floor.** Facilitators available for questions. Attendees can photograph their contributions. Collect remaining materials. | All facilitators | Leave dice on tables — people will naturally linger and talk. |
+
+**Post-workshop (facilitator responsibility):**
+
+- Photograph all Contribution Wall items
+- Digitize playtesting feedback → GitHub issues or structured data for maintainer
+- Digitize scenario cards → PRs with contributor attribution
+- Send Discord message thanking participants by table/scenario
+- Share photos from the session
+
+---
+
+## Facilitator Roles & Prep
+
+### Role Assignments
+
+| Role | Person | Responsibilities |
+|------|--------|-----------------|
+| **Lead Facilitator** | Project Owner | Hook pitch, whole-room debrief, contribution onboard, showdown MC, wall walkthrough. NOT running a table during play (floats between tables, handles logistics). |
+| **Table IM 1** | [TBD] | Runs 1-2 tables during Immersion. Circulates during Creation. |
+| **Table IM 2** | [TBD] | Runs 1-2 tables during Immersion. Circulates during Creation. |
+| **Volunteer IMs** | Recruited if 25+ attendees | Brief 30 min before doors. Run 1 table each. |
+
+**Key insight from research:** The lead facilitator should not run a table. They need to float — handling late arrivals, monitoring energy, preparing the next movement. Running a table locks you to 5-6 people when you need to serve 40.
+
+### Facilitator Prep Timeline
+
+| When | What | Who |
+|------|------|-----|
+| **T-8 weeks** | Finalize scenario selection. Order/print physical materials. | Lead facilitator |
+| **T-4 weeks** | All IMs: (1) Read the Visual Guide cover-to-cover (8 pages, 10 min). (2) Read IM Quick Start Guide. (3) Read the LockBit Hospital Emergency scenario card + planning doc. (4) Run a practice session using the zero-prep FakeBat or GaboonGrabber onboarding scenario first. | All IMs |
+| **T-2 weeks** | Dry run: full 4-hour rehearsal with friends/colleagues as attendees. | All facilitators |
+| **T-1 week** | Print all materials. Test Contribution Wall setup. Prepare prize bag. | Lead facilitator |
+| **T-30 min** | Set up room. Tables, materials, screen, wall space. Brief volunteer IMs. | All facilitators |
+| **T-0** | Doors open. Music on. Countdown on screen. | Lead facilitator |
+
+---
+
+## Physical Materials Checklist
+
+### Per Table (5-seat)
+- [ ] 1-2x d20 dice (1 per player ideal, 1 per table minimum)
+- [ ] 4x **Printed Tent Cards** (from `players-handbook/resources/player-tent-cards.html` — A4 landscape, cut in half, fold. Role name faces outward, modifiers face player. Print 2 sheets = 4 roles.)
+- [ ] 1x printed **Visual Guide** (from `im-handbook/resources/practical-tools/visual-guide.html` — 8 pages, A4. THE player onboarding document.)
+- [ ] 4-5x **Players Quick Start** (from `players-handbook/resources/players-quick-start.html` — 1 page each)
+- [ ] 1x scenario packet (scenario card + evidence handouts A/B/C + NPC reference — print from scenario card directory)
+- [ ] 5x pens (good ones, not hotel pens)
+- [ ] Scratch paper pad
+- [ ] 1x large notecard + thick marker (for gallery walk)
+- [ ] 2-3x playtesting feedback templates (1 per pair)
+- [ ] 1-2x scenario creation templates (for tables that choose Path B)
+
+### Room-Level
+- [ ] Projector/screen for hook pitch + scenario anatomy
+- [ ] Contribution Wall: cork board, easel, or wall space with tape/pins
+- [ ] QR code printout (Discord invite, project URL) — large, photographable
+- [ ] Spare dice
+- [ ] Prizes: stickers, custom dice, challenge coins, or M&M art prints
+- [ ] Small speaker for ambient music (maybe an iPod + aux cord)
+- [ ] Power strips (facilitator laptops)
+- [ ] USB drives (offline contribution collection fallback)
+
+### Printed Documents (Facilitator Copies Only)
+- [ ] **Scenario planning document** (1 per IM — from `im-handbook/resources/scenario-planning-docs/ransomware-advanced/lockbit-hospital-planning.qmd`)
+- [ ] **IM Quick Start Guide** (1 per IM — from `im-handbook/resources/practical-tools/im-quick-start-guide.html`)
+- [ ] **Large-Group Facilitator Guide** for LockBit Hospital Emergency (if 25+ attendees — from `im-handbook/resources/scenario-cards/lockbit/hospital-emergency/large-group/large-group-facilitator.qmd`)
+- [ ] **Debrief Protocol** (1 for lead facilitator — from `im-handbook/resources/practical-tools/facilitation-guides/debrief-protocol.qmd`)
+- [ ] **Network Security Status Tracker** (1 per IM — from `im-handbook/resources/practical-tools/session-materials/network-security-status-tracker.qmd`)
+- [ ] **Evidence Cards** (generic blanks for creation phase — from `im-handbook/resources/practical-tools/session-materials/evidence-cards.qmd`)
+- [ ] Facilitation pacing cheat sheet (this syllabus, condensed to 1 page)
+- [ ] Emergency protocol: what to do if [fire alarm / medical / attendee conflict]
+
+---
+
+## Attendee Prerequisites
+
+**Required:** Nothing. Show up.
+
+**Helpful but not required:**
+
+- GitHub account (for post-workshop attribution — facilitators can attribute without it)
+- Having heard of incident response (DEFCON audience: assume yes)
+- Familiarity with any tabletop game (helpful for roleplay comfort)
+
+**Explicitly NOT required:**
+
+- Laptop (this is paper-first)
+- Network access
+- Prior M&M experience
+- Programming ability
+- Git knowledge
+
+---
+
+## Network Failure Plan
+
+The workshop is designed offline-first. Here's what changes if network IS available:
+
+| Component | Offline (default) | Online (bonus) |
+|-----------|-------------------|----------------|
+| Game play | Paper, dice, printed cards | Same — no digital dependency |
+| Contribution capture | Paper templates → facilitator collects | Same — paper is primary |
+| PR submission | Facilitators digitize post-workshop | Live PR during session via Codespaces (if mm-scenario agent ready) |
+| Discord invite | QR code to photograph | Live join during session |
+| Scenario display | Printed/projected from facilitator laptop | Same |
+
+**If mm-scenario agent is ready by DEFCON:**
+
+- Add an optional "digital fast lane" for attendees who bring laptops and want the Codespaces experience
+- This is a BONUS track, not the primary path
+- 2-3 attendees max will take this path; most will prefer paper
+- The agent helps them create a PR in real-time — this is a great demo/spectacle for the room
+
+---
+
+## Comparison to Original Concept
+
+| Aspect | Original (90/150) | This Proposal | Why |
+|--------|-------------------|---------------|-----|
+| **Time split** | 90 min play / 150 min contribute | 100 min play / 100 min create+showcase / 40 min transitions+close | Play needs full arc for buy-in. Contribution loses time but gains energy. |
+| **Contribution target** | Scenario card PRs via Codespaces | Playtesting feedback (primary) + scenario cards (advanced), on paper | Feedback is higher value and lower barrier. Paper removes network dependency. |
+| **Contribution mechanism** | Each attendee submits a PR | Facilitators collect and digitize post-workshop | Removes git/GitHub as attendee blocker. Attribution still happens. |
+| **Network dependency** | High (Codespaces) | None (offline-first) | DEFCON network reality. |
+| **AI agent dependency** | High (mm-scenario required) | None (bonus if available) | Agent not confirmed ready. Design must work without it. |
+| **Energy management** | Implicit | Explicit: gallery walk, showdown, modality switching | 4 hours demands deliberate energy design. |
+| **Post-workshop value** | PRs merged | Structured playtesting data + scenario cards + community connection | Multiple value streams, not just code contribution. |
+
+**What's preserved from the original:**
+
+- The core concept: play then contribute
+- Scenario cards as a contribution format (elevated to advanced path)
+- The vision of real contributions from workshop attendees
+- Codespaces as a possibility (just not the only path)
+
+**What's changed:**
+
+- Play gets more time (emotional investment drives contribution quality)
+- Paper-first removes the biggest single point of failure
+- Playtesting feedback recognized as a first-class contribution
+- Competitive showdown replaces the energy vacuum at hour 3
+- Lead facilitator floats instead of running a table
+
+---
+
+## Pre-Workshop Project Improvements
+
+### MUST (workshop breaks without these)
+
+| Item | Status | Impact | Effort |
+|------|--------|--------|--------|
+| **Playtesting feedback template** | NEW — does not exist | The primary contribution format. Needs to be designed, tested, printed. | Medium — template design + 1 playtest cycle |
+| **Scenario creation template** | PARTIAL — scenario card format exists in repo, needs printable fill-in-the-blank version | The advanced contribution format. Extract fields from existing LockBit scenario cards. | Low — reformat existing structure |
+| **LockBit Hospital Emergency tuned to 75 min** | EXISTS but needs compression notes — full game is 120-140 min, Visual Guide says "cut to Round 3 if time is short" | Need specific pacing guidance for 75-min version: which evidence cards to skip, where to compress Investigation. | Medium — IM playtesting to find cuts |
+| **IM pacing cheat sheet for workshop** | NEW | 1-page facilitator reference: what happens when, key transitions, emergency protocols. | Low — extract from this syllabus |
+
+**Already exists (no work needed):**
+
+- Tent cards: `players-handbook/resources/player-tent-cards.html` — print A4 landscape, cut, fold
+- Visual Guide: `im-handbook/resources/practical-tools/visual-guide.html` — 8-page printable onboarding
+- Players Quick Start: `players-handbook/resources/players-quick-start.html` — 1-page printable
+- Role Distributor: `im-handbook/resources/practical-tools/session-materials/role-distributor.html`
+- IM Quick Start Guide: `im-handbook/resources/practical-tools/im-quick-start-guide.html`
+- Evidence cards (generic blanks): `im-handbook/resources/practical-tools/session-materials/evidence-cards.qmd`
+- Evidence handouts (LockBit-specific): `im-handbook/resources/scenario-cards/lockbit/hospital-emergency/handout-*.qmd`
+- Network Security Status Tracker: `im-handbook/resources/practical-tools/session-materials/network-security-status-tracker.qmd`
+- Debrief Protocol: `im-handbook/resources/practical-tools/facilitation-guides/debrief-protocol.qmd`
+- Large-Group Facilitator Guide (LockBit Hospital): `im-handbook/resources/scenario-cards/lockbit/hospital-emergency/large-group/large-group-facilitator.qmd`
+
+### SHOULD (significantly improves quality)
+
+| Item | Status | Impact | Effort |
+|------|--------|--------|--------|
+| **Workshop Facilitator Guide** | #165 — Project owner leading | Comprehensive facilitator prep document. This syllabus is the skeleton; #165 is the muscle. | High |
+| **Scenario validation rubric** | NEW | 3-criteria checklist printed on back of scenario creation template. Prevents unusable content. | Low — 3 questions |
+| **Gallery Walk notecard template** | NEW | Pre-printed "Our Malmon / Our Outcome / The Moment Everything Went Sideways" | Trivial |
+| **Volunteer IM briefing one-pager** | NEW | Condensed reference for recruited volunteer IMs who get 30 min of prep | Low — extract from IM Quick Start + this syllabus |
+
+### NICE TO HAVE (enhances but not critical)
+
+| Item | Status | Impact | Effort |
+|------|--------|--------|--------|
+| **Kernels/Satellites framework** | #203 — stub only in Obsidian | Helps IMs know what's load-bearing vs. flexible when compressing to 75 min. Would directly inform the compression notes. | Medium |
+| **NPC Library** | #155 — stub only in Obsidian | Pre-built NPC cards make IM improvisation smoother. Our pattern library from #221 has 8 NPC dialogue function types. | Medium |
+| **mm-scenario agent** | Not started | Digital fast lane for laptop-equipped attendees. Spectacular demo if it works. | High |
+| **Custom M&M dice/stickers** | New | Physical prizes for the Showdown. Community builder. | Low cost, high impact |
+| **Improv techniques chapter** | #46 | Helps IMs handle unexpected participant actions during compressed play. | Medium |
+
+---
+
+## Scaling Guide
+
+| Attendees | Tables (4-5 per) | IMs Needed | Adaptation |
+|-----------|------------------|------------|------------|
+| 8-15 | 2-3 | 2 (lead floats) | Intimate. Every table gets deep attention. Showdown is friendly, not competitive. |
+| 15-25 | 3-5 | 3 (lead floats) | **Sweet spot.** All movements work as designed. 4 core roles per table. |
+| 25-35 | 5-7 | 4-5 (recruit 1-2 volunteers) | Consider **large-group format**: 3 teams of 8-12, each with own IM, using the LockBit Hospital Emergency large-group guide (21 tiered artifacts, Alpha/Bravo/Charlie team structure). Showdown uses bracket format. |
+| 35-40 | 3 large teams or 7-8 small | 5-6 | Large-group format strongly recommended. 3 teams each run the same scenario with different evidence streams, then debrief together. The large-group facilitator guide was designed for exactly this. |
+| 40+ | Split rooms | 6+ | Two rooms with separate leads. Coordinate for combined Showdown. |
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Network down | High | Low (offline-first design) | Already mitigated by paper-first approach |
+| Fewer than 15 attendees | Medium | Medium — room feels empty | Works fine at 10. Shrink to 2 tables, skip competitive showdown, do collaborative showcase instead |
+| 40+ attendees | Low | High — not enough IMs | Cap registration. Recruit volunteer IMs from DEFCON community pre-event |
+| IMs not confident with LockBit | Medium | Medium | Fall back to FakeBat. Brief IMs early. Practice session at T-2 weeks is critical |
+| Attendees leave at hour 2 | Medium | Low — workshop designed for it | Gallery Walk is a natural exit point. Those who stay are self-selected for creation |
+| No one chooses scenario creation | Low | Low | Feedback is the primary path anyway. Showdown adapts to "feedback highlight reel" |
+| Dominant player takes over table | Medium | Medium — others disengage | IM training: "I want to hear from [quiet player]'s perspective as the [role]." Role cards give IMs a tool for this |
+| Contribution quality is low | Medium | Low — facilitators curate post-workshop | Validation rubric on templates. Facilitators review before digitizing. No bad PRs escape |
+
+---
+
+## Open Questions
+
+1. **Scenario selection:** LockBit Hospital Emergency is recommended — it has the most complete material set (scenario card, planning doc, large-group guide, 21 artifacts). Does the team have enough LockBit experience, or should we default to FakeBat (fully scripted, zero-improvisation onboarding scenario)?
+
+2. **Small tables or large-group format?** For 25+ attendees, the LockBit Hospital Emergency large-group guide supports 3 teams (Alpha/Bravo/Charlie) with tiered evidence and a coordination layer. This maps naturally to a DEFCON room. Do you prefer many small tables or fewer large teams?
+
+3. **Multiple scenarios:** Should all tables play the SAME scenario (simpler logistics, shared debrief) or DIFFERENT scenarios (more interesting gallery walk, but fragmented debrief)?
+
+4. **The Visual Guide as handout:** Just shipped the 8-page Visual Guide as the primary entry point. Should we print this for every table, or is there a better workshop-specific version planned?
+
+5. **Volunteer IM recruitment:** Is there a DEFCON community/village where experienced M&M players could be recruited as volunteer IMs? The zero-prep onboarding scenarios (FakeBat, GaboonGrabber) could serve as their practice run.
+
+6. **Prizes/swag:** Is there budget for M&M stickers, custom dice, or contributor badges? These are cheap and high-impact for the Showdown.
+
+7. **Registration cap:** Should this be capped? What's the maximum the room can support?
+
+8. **mm-scenario agent timeline:** Is it realistic to have a working version by DEFCON for the "digital fast lane" bonus track?
+
+9. **Post-workshop digitization:** Who takes responsibility for converting paper contributions to GitHub issues/PRs? What's the turnaround target?
+
+10. **Dry run:** When and where for the T-2 week rehearsal? Can we recruit 10-15 playtesters?
+
+11. **This syllabus:** What resonates? What feels wrong? What's missing from your experience running workshops?


### PR DESCRIPTION
## Summary

Adds the DEFCON 2026 4-hour workshop syllabus from Chris (TrustedSec) and Kai, received 2026-04-20 (email msgId 19dabed46d804b3b).

**File:** docs/workshops/defcon-2026-syllabus.md

The syllabus covers the full player-to-designer arc across 7 movements (240 min), including facilitator roles, prep timeline, materials checklist, scaling guide, and risk register. LockBit Hospital Emergency is the recommended scenario.

Note on _quarto.yml: docs/workshops/ is a new path not currently in the site nav. Left standalone -- Klaus to review before adding to Quarto config.

## Planning issue

#256 -- Planning: DEFCON 2026 M&M Workshop

## Changes

- New directory: docs/workshops/
- New file: docs/workshops/defcon-2026-syllabus.md (489 lines, Quarto front-matter, source-faithful with list-spacing hook fixes)
- No config files modified
- No theming changes