### PR TITLE
fix(scripts): add missing enhancement + design cases in create-issue.sh

### DIFF
--- a/scripts/create-issue.sh
+++ b/scripts/create-issue.sh
@@ -268,8 +268,13 @@ if [[ -n "$LABELS" ]]; then
 fi
 
 # Add type-based label
+# These map --type values to the GitHub labels the validate-issue-fields workflow
+# regex-checks for: ^(enhancement|bug|documentation|technical-debt)$
 case $TYPE in
   feature)
+    LABEL_LIST="${LABEL_LIST:+$LABEL_LIST,}enhancement"
+    ;;
+  enhancement)
     LABEL_LIST="${LABEL_LIST:+$LABEL_LIST,}enhancement"
     ;;
   bug)
@@ -277,6 +282,9 @@ case $TYPE in
     ;;
   documentation)
     LABEL_LIST="${LABEL_LIST:+$LABEL_LIST,}documentation"
+    ;;
+  design)
+    LABEL_LIST="${LABEL_LIST:+$LABEL_LIST,}enhancement"
     ;;
   maintenance)
     LABEL_LIST="${LABEL_LIST:+$LABEL_LIST,}technical-debt"


### PR DESCRIPTION
## Bug

`scripts/create-issue.sh` had a type-label switch missing arms for
`enhancement` and `design`. Issues created with `--type enhancement` (or
`--type design`) got NO type-label attached, so `Validate Issue Project Fields`
workflow failed every `issues` event with "missing required type label."

## Repro

Today's batch:
- 6 D&D Comparative Inspirations (#247–#252), all created via `--type enhancement`,
  each fired 4 failed validation runs.
- Total: 24 failed runs, all spurious.

## Fix

- `enhancement` → labels `enhancement`
- `design` → labels `enhancement` (no `design` in workflow regex; refine later if needed)

## Already done outside this PR

- #247–#252 retro-fixed via `gh issue edit N --add-label enhancement`. They will pass validation on next event.

## Out of scope

- Multi-run spam (Bug B in #246) — covered by concurrency-group patch.