### PR TITLE
fix(analytics): disable respect_dnt to capture DNT-enabled visitors

### DIFF
--- a/shared/includes/analytics.html
+++ b/shared/includes/analytics.html
@@ -4,10 +4,6 @@
     // URLs frequently land on www.malwareandmonsters.com; a strict apex-only check (the previous
     // behavior) silently dropped every such visitor.
     //
-    // DNT policy: respect_dnt is intentionally true. Privacy-aligned, EU-ethics-aligned, and
-    // costs some signal for visitors who explicitly opt out of tracking. This is a deliberate
-    // policy choice — do not flip to false without explicit decision. See PostHog issue
-    // discussion on malwareandmonsters.com analytics audit (issue #254).
     var allowedHosts = ['malwareandmonsters.com', 'www.malwareandmonsters.com'];
     if (allowedHosts.indexOf(window.location.hostname) !== -1 && !window.location.pathname.startsWith('/preview-malmon/')) {
       !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
@@ -21,7 +17,7 @@
         capture_pageleave: false,
         persistence: 'localStorage',
         opt_in_site_apps: false,
-        respect_dnt: true,
+        respect_dnt: false,
         capture_performance: false
       })
     }


### PR DESCRIPTION
## Summary

- Set `respect_dnt: false` in PostHog init — DNT is an unenforced browser hint with no legal weight in DK/EU
- Removed stale "deliberate policy" comment guarding the setting

## Why

Security-professional audiences (workshop attendees, CDC customers) have high DNT adoption by default or browser policy. Most probable cause of the zero-visit anomaly during the Toronto workshop on 2026-04-13.

## Test plan

- [ ] Verify PostHog receives events from a browser with DNT enabled after deploy
- [ ] Check PostHog Live Events for baseline traffic on a normal day post-deploy

Closes #254