### PR TITLE
feat(workshop): redesign DEF CON 2026 syllabus around AI-assisted PR contribution

### DIFF
--- a/docs/workshops/defcon-2026-syllabus.md
+++ b/docs/workshops/defcon-2026-syllabus.md
@@ -1,0 +1,289 @@
+---
+title: "DEF CON 2026 Workshop: Malware & Monsters"
+subtitle: "Player to Contributor — AI-assisted scenario creation"
+date: "2026-04-27"
+status: "WIP — brainstorming document, not final"
+---
+
+# DEF CON 2026 Workshop: Malware & Monsters
+
+> **Status:** Work in progress. Approaches and tooling are not yet decided. This document is intentionally exploratory.
+
+---
+
+## Workshop Concept
+
+Malware & Monsters is a tabletop incident response game where players handle live cyber incidents in role. This workshop takes participants from their first encounter with the game to submitting a real contribution to the open-source project — in four hours, with AI assistance.
+
+The arc is **player to contributor**. Participants experience the game first-hand, then use a preconfigured AI-assisted environment to design and submit a new scenario as a GitHub pull request before they leave the room. The AI handles the technical scaffolding — format, structure, PR mechanics — so participants focus entirely on the creative and security content.
+
+The workshop is also a live demonstration: AI-assisted tooling enabling non-technical contributors to produce valid open-source contributions in under an hour.
+
+---
+
+## Objective
+
+Every participant leaves having submitted a pull request containing a new M&M scenario to the project repository.
+
+---
+
+## Format
+
+- **Duration:** 4 hours (240 minutes)
+- **Attendees:** 15–40
+- **Facilitators:** 3 minimum (1 lead + 2 table IMs). Recruit volunteer IMs for 25+ attendees.
+
+---
+
+## Timetable
+
+```
+TIME           MOVEMENT                        DURATION
+──────────────────────────────────────────────────────
+0:00 – 0:20    ARRIVAL + ENVIRONMENT SETUP     20 min
+0:20 – 1:00    IMMERSION                       40 min
+1:00 – 1:10    BREAK                           10 min
+1:10 – 1:25    DISSECTION                      15 min
+1:25 – 2:15    AI-GUIDED CREATION              50 min
+2:15 – 2:35    VALIDATE + SUBMIT PR            20 min
+2:35 – 3:20    SHOWCASE                        45 min
+3:20 – 4:00    VISION + CLOSE                  40 min
+──────────────────────────────────────────────────────
+               TOTAL                          240 min
+```
+
+---
+
+## Movement Descriptions
+
+### 1. Arrival + Environment Setup (0:00 – 0:20)
+
+Participants self-seat. Screens show a single QR code and one instruction: open the URL and sign in with GitHub. While they settle, they authenticate into the AI creation environment — so setup happens during the natural drift of arrival, not as a dedicated task.
+
+The lead facilitator delivers a 3-minute story pitch at 0:10. Not a rules explanation — a hook: "In the next 40 minutes your table is going to handle a live cyber incident. You don't need to know the rules. Your IM will handle everything."
+
+Role cards distributed by table IMs. Each player introduces themselves in-character (30 seconds each).
+
+**Facilitator notes:**
+
+- Late arrivals welcome through 0:30. IMs catch them up in-character.
+- Environment setup must be self-service — facilitators should not be helping with logins during this phase. QR code URL must work first-try on a phone browser.
+
+---
+
+### 2. Immersion (0:20 – 1:00)
+
+Participants play a compressed M&M session using one of the zero-prep scenarios (GaboonGrabber or FakeBat). These are fully scripted — IMs need no prior preparation beyond a single read-through.
+
+The session runs through **Round 1 in full** (~25 minutes), then the IM narrates the malmon reveal from Round 2 (~5 minutes) rather than playing it out. This gives participants the complete experience arc — hook, investigation, decision point, and the "oh wow, this is based on a real malware family" moment — without requiring the full 90-120 minute runtime.
+
+**Why compress here:** participants do not need to finish a scenario to understand how to design one. Round 1 shows them everything load-bearing: how the organisation and hook create urgency, how NPCs work, how clue prompts drive investigation, how decision points feel. Rounds 2 and 3 add resolution mechanics and type effectiveness — useful gameplay, but not necessary for the creation task ahead.
+
+**Scenario selection:** GaboonGrabber (phishing / credential theft) or FakeBat (malvertising / downloader). Both are beginner-tier, fully scripted, and require zero prep. Run the same scenario across all tables for a shared debrief in Movement 4.
+
+---
+
+### 3. Break (1:00 – 1:10)
+
+Physical reset. IMs post a single notecard per table on the wall: malmon name, outcome, and "the moment everything went sideways." Participants browse other tables' cards during the break — seeds the "what would I do differently" mindset and functions as a lightweight harvest of the play experience.
+
+---
+
+### 4. Dissection (1:10 – 1:25)
+
+The highest-leverage 15 minutes in the workshop. Lead facilitator displays the scenario card they just played on screen and walks through every field: organisation, hook, pressure, NPCs, secrets, villain plan. "You just played this. Here's what was on my cheat sheet. Remember when [NPC] called about [event]? That was this field. The reason [plot point] happened? That was this secret."
+
+Demystification is the bridge from player to designer. Participants leave this movement understanding that the experience they just had was constructed from a small number of deliberate choices — choices they are about to make themselves.
+
+Close with a single sentence: "You're going to build one of these in the next 50 minutes. The AI will guide you through every field."
+
+---
+
+### 5. AI-Guided Creation (1:25 – 2:15)
+
+Participants open the AI creation environment (already authenticated from Movement 1) and begin. The AI conducts a structured interview: organisation, stakes, hook, NPCs, secrets, villain plan. Participants answer in plain language. The AI generates a valid scenario in the repository format.
+
+The session is split:
+
+- **Sprint 1 (25 min, 1:25–1:50):** AI interview, first complete draft generated.
+- **Peer check-in (5 min, 1:50–1:55):** Participants show their neighbour the draft. Written exchange: one thing that works, one thing missing. Loud, social, brief energy reset.
+- **Sprint 2 (20 min, 1:55–2:15):** Iterate on feedback, finalise.
+
+**Why split with peer check-in:** 50 minutes of individual heads-down work at hour 2.5 is a documented energy valley in workshop design. The check-in breaks it into two focused sprints with a social moment between them.
+
+**What the AI does:** asks questions, accepts plain-language answers, formats the scenario correctly, validates completeness (minimum decision points, realistic threat actor, resolvable in 30 minutes of play), flags gaps. Participants do not need to know the scenario format.
+
+---
+
+### 6. Validate + Submit PR (2:15 – 2:35)
+
+The AI runs a final validation pass and, on approval, submits a pull request to the M&M repository with the participant's GitHub account. Name goes in the git history.
+
+A live counter on the shared screen updates as PRs land. This is the moment of visible collective output — watching the number climb is the energy peak of the close.
+
+Facilitators circulate to unblock anyone stuck. Common issues: incomplete NPC motivations, villain plan lacking a second stage, organisation too generic. AI flags these — facilitators help resolve.
+
+---
+
+### 7. Showcase (2:35 – 3:20)
+
+Lead facilitator reads submitted scenarios aloud — one from each table, selected for variety or quality. The room hears what was built in 50 minutes with AI assistance.
+
+This movement serves two purposes: celebration of what the room produced, and live quality signal. If the scenarios read well, the AI tooling is validated. If they read rough, the facilitators take note for the post-workshop retrospective and for improving the creation tool before future events.
+
+Participants can photograph the PR counter and their own scenario on screen. Discord QR code is live.
+
+---
+
+### 8. Vision + Close (3:20 – 4:00)
+
+Lead facilitator delivers the vision pitch: "Here's where this project was two years ago. Here's where it is today. With the scenarios you submitted this afternoon, here's where it could be next year."
+
+Sells the community trajectory, not just the event. Participants leave knowing their contribution has a destination.
+
+Followed by: Discord invite, next playtest date if known, open floor. Facilitators available for questions. Dice stay on tables — people linger and talk.
+
+**Post-workshop (facilitator responsibility):**
+
+- Review submitted PRs for quality. Merge what's solid, comment with feedback on what needs work.
+- Send Discord message thanking participants by scenario name.
+- Share photos from the session.
+
+---
+
+## Technical Platform
+
+> **WIP:** Two approaches are in consideration. The choice will be made after a dry run, no later than 8 weeks before DEF CON.
+
+### Architecture Overview
+
+The creation pipeline has three components:
+
+1. **AI layer** — conducts the scenario interview, generates structured output, validates completeness
+2. **GitHub layer** — authenticates participants, submits PRs on their behalf
+3. **Environment** — where participants interact with the AI (browser, CLI, or Codespace)
+
+The two approaches differ primarily in component 3 and the coupling between 1 and 3.
+
+---
+
+### Option A: Claude Code Skills + Codespaces / Gitpod
+
+Participants get a preconfigured cloud development environment (GitHub Codespaces or Gitpod) with the M&M repository cloned, Claude Code CLI installed, and custom skills pre-loaded. They open the environment and run a slash command (`/new-scenario`) to begin.
+
+**How it works:**
+
+- Facilitator prepares a Codespace or Gitpod template with all dependencies pre-installed
+- Participants launch from a QR code, authenticate with GitHub
+- Claude Code skills guide them through scenario creation via slash commands
+- `gh` CLI (pre-authenticated) submits the PR
+
+**Codespaces (primary):** GitHub product. Participants use their own GitHub free-tier accounts on the public M&M repo. Free tier includes 120 core-hours/month; a 2-hour session on a 2-core machine uses 4 core-hours — well within the limit. Cost to workshop organiser: ~$0. **Pricing confidence: 65%** — GitHub revises free tier terms periodically.
+
+**Gitpod (EU alternative, Gitpod GmbH, Hamburg DE):** Historically comparable to Codespaces for public repos. However, Gitpod is actively sunsetting their hosted cloud service (gitpod.io) in favour of a self-hosted product (Gitpod Flex). Availability and pricing as of DEF CON 2026 are uncertain. **Pricing/availability confidence: 25%** — verify status closer to the event.
+
+**Self-hosted (Coder, DevPod by Loft Labs Munich DE, code-server):** Open-source, runs on any EU infrastructure. Software is free; infrastructure cost for workshop day ~€5–15 on Hetzner or equivalent. Significant setup effort. **Cost confidence: 70%.**
+
+**Estimated probability this approach works end-to-end for the workshop: 0.60**
+
+Primary risks: DEFCON network reliability for Codespace launch; participant friction requiring Anthropic API access or shared key; locked to Claude as LLM.
+
+---
+
+### Option B: Custom Agent (Web App or CLI)
+
+A purpose-built tool — a web application or lightweight CLI — backed by any LLM API. Participants open a URL, authenticate GitHub via OAuth, chat with the agent, and the PR is submitted via the GitHub API. No Codespaces, no Claude Code, no dev environment required.
+
+**How it works:**
+
+- A hosted web app (or installable CLI) wraps an LLM API with M&M-specific tool definitions
+- Participants authenticate via GitHub OAuth on first load
+- The agent interviews them, generates the scenario, submits the PR via GitHub API
+- Hosted on EU infrastructure (Hetzner, Fly.io EU region, etc.)
+
+This approach removes the dev environment layer entirely. Participant requirement reduces to: a browser and a GitHub account.
+
+It is also **LLM-agnostic** — the agent can be backed by Claude, GPT-4.1, Gemini, or any OpenAI-compatible API. The LLM can be swapped without changing participant experience.
+
+**Infrastructure cost:** ~€5–20/month for a lightweight EU-hosted app during development + workshop day. **Cost confidence: 70%.**
+
+**Estimated probability this approach works end-to-end for the workshop: 0.75**
+
+Higher probability than Option A primarily due to lower participant friction and fewer infrastructure dependencies. Primary risk: build effort is greater than Option A.
+
+---
+
+### LLM Options
+
+Applies to both approaches. All credible options are US-based — tested EU alternatives (Mistral et al.) are not competitive for structured creative generation at the quality required.
+
+| Model | Input | Output | Workshop cost ~40 pax | Quality | Notes |
+|-------|-------|--------|-----------------------|---------|-------|
+| **Claude Sonnet 4.6** | $3/MTok | $15/MTok | ~$1–3 | Excellent | Required for Option A. Recommended for Option B if familiarity is a factor. Native schema enforcement. |
+| **Claude Haiku 4.5** | $1/MTok | $5/MTok | ~$0.35–1 | Excellent | Same schema quality as Sonnet at 3× lower cost. Strong budget option for Option B. |
+| **GPT-4.1** | $2/MTok | $8/MTok | ~$0.65–2 | Excellent | Strongest non-Claude option. 1M context. Option B only. |
+| **Gemini 2.5 Pro** | $1.25/MTok | $10/MTok | ~$0.55–2 | Excellent | Best price at frontier quality. Google Cloud EU data residency available. Option B only. |
+| **Llama 3.3 70B (Groq)** | $0.59/MTok | $0.79/MTok | ~$0.20–0.50 | Acceptable | Already in stack. Ultra-fast inference. 5–20% parse failure on complex schemas without constrained decoding — needs retry logic. Not recommended as sole primary. |
+
+**All pricing confidence: 70%** — verified from official sources April 2026, but API pricing changes frequently.
+
+---
+
+### What "Preconfigured" Means
+
+Regardless of approach, participants should arrive at a state where:
+
+- GitHub is authenticated (write access to fork or branch)
+- The scenario template is pre-loaded in context
+- The M&M scenario format is encoded in the AI's instructions
+- The PR target (branch, repo, file path) is pre-set
+- Validation criteria are baked in (the AI knows what makes a complete scenario)
+
+Participants provide only the creative content. Everything else is handled.
+
+---
+
+## Participant Prerequisites
+
+- GitHub account
+- A device with a browser
+
+Nothing else. No laptop required if mobile GitHub OAuth works for the chosen approach. No git knowledge. No prior M&M experience. No programming ability.
+
+---
+
+## Facilitator Requirements
+
+| Role | Count | Responsibilities |
+|------|-------|-----------------|
+| Lead facilitator | 1 | Story pitch, whole-room debrief, showcase MC, vision close. Does NOT run a table. |
+| Table IM | 2 minimum | Run tables during Immersion. Circulate and unblock during Creation. |
+| Volunteer IMs | +1 per 8 attendees above 24 | Brief 30 min before doors. Run one table each. |
+
+**Prep timeline:**
+
+| When | What |
+|------|------|
+| T-8 weeks | Scenario selection finalised. AI creation tool dry run. |
+| T-6 weeks | Decision: Option A or Option B. Build begins. |
+| T-4 weeks | All IMs: read zero-prep scenario cover to cover. Run one practice session. |
+| T-2 weeks | Full dry run with real participants. Scenarios produced evaluated for quality. If rough: add iteration sprint, reduce showcase. |
+| T-1 week | Print materials. Test environment end-to-end. |
+| T-30 min | Room setup, tables, QR codes on screen, brief volunteer IMs. |
+
+---
+
+## What Needs to Be Built
+
+| Item | Approach | Effort | Priority |
+|------|----------|--------|----------|
+| AI creation tool (skills or agent) | A or B | High | Critical |
+| Codespace / Gitpod template | A only | Medium | Critical if A chosen |
+| Hosted web app + GitHub OAuth | B only | Medium | Critical if B chosen |
+| Scenario PR template (branch, path, format) | Both | Low | Critical |
+| AI validation criteria (completeness rubric) | Both | Low | Critical |
+| IM pacing cheat sheet (1 page) | Both | Low | Should |
+| QR code assets | Both | Trivial | Should |
+| Dry run participant recruitment (10–15 people, T-2 weeks) | Both | Medium | Should |
+
+**Decision gate:** Option A vs Option B must be decided no later than T-6 weeks (approximately mid-June 2026 for a DEF CON August event).


### PR DESCRIPTION
## Summary

- Replaces dual-path (feedback form + scenario creation) with single objective: every participant submits a scenario PR before leaving
- Immersion compressed to 40 min (Round 1 + malmon reveal narrated)
- AI-guided creation sprint (50 min) with peer check-in replaces paper-first approach
- Showcase at close serves as live validation of AI tooling quality
- Technical platform section covers two approaches (Claude Code skills vs custom agent) with p(success) estimates, LLM options and pricing

## Status

WIP brainstorming document. Tooling approach (Option A vs B) and LLM choice deferred to post-dry-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)