### PR TITLE
Revise DEF CON 2026 syllabus

### DIFF
--- a/docs/workshops/defcon-2026-syllabus.md
+++ b/docs/workshops/defcon-2026-syllabus.md
@@ -1,29 +1,31 @@
 ---
 title: "DEF CON 2026 Workshop: Malware & Monsters"
-subtitle: "Player to Contributor — AI-assisted scenario creation"
-date: "2026-04-27"
-status: "WIP — brainstorming document, not final"
+subtitle: Player to Contributor — AI-assisted scenario creation
+status: Ready for submission
 ---
 
 # DEF CON 2026 Workshop: Malware & Monsters
 
-> **Status:** Work in progress. Approaches and tooling are not yet decided. This document is intentionally exploratory.
+> **Status:** Work in progress. Approaches and tooling are not yet finalized. Technical implementation choices will be ironed out after submission and before the build phase.
 
 ---
 
 ## Workshop Concept
 
-Malware & Monsters is a tabletop incident response game where players handle live cyber incidents in role. This workshop takes participants from their first encounter with the game to submitting a real contribution to the open-source project — in four hours, with AI assistance.
+Malware & Monsters is a tabletop incident response game where players handle live cyber incidents in role. This workshop takes participants from their first encounter with the game to submitting a real contribution to the open-source project, in four hours, with AI assistance.
 
 The arc is **player to contributor**. Participants experience the game first-hand, then use a preconfigured AI-assisted environment to design and submit a new scenario as a GitHub pull request before they leave the room. The AI handles the technical scaffolding — format, structure, PR mechanics — so participants focus entirely on the creative and security content.
 
-The workshop is also a live demonstration: AI-assisted tooling enabling non-technical contributors to produce valid open-source contributions in under an hour.
+The workshop is also a live demonstration: AI-assisted tooling enabling non-technical contributors to produce valid open-source contributions in under an hour, with quality assurance happening live.
 
 ---
 
-## Objective
+## Objectives
 
-Every participant leaves having submitted a pull request containing a new M&M scenario to the project repository.
+1. **Workshop objective (T+0):** Every participant leaves having submitted a quality-validated pull request containing a new scenario.
+2. **Project objective (T+30 days):** Validated submissions are merged into `main`. Participants whose submissions need iteration have a clear path to completing post-workshop.
+
+Live in-workshop QA (Movement 6) collapses most of the gap between the two.
 
 ---
 
@@ -46,11 +48,14 @@ TIME           MOVEMENT                        DURATION
 1:10 – 1:25    DISSECTION                      15 min
 1:25 – 2:15    AI-GUIDED CREATION              50 min
 2:15 – 2:35    VALIDATE + SUBMIT PR            20 min
-2:35 – 3:20    SHOWCASE                        45 min
-3:20 – 4:00    VISION + CLOSE                  40 min
+2:35 – 3:00    SHOWCASE                        25 min
+3:00 – 3:30    VISION + CLOSE                  30 min
+3:30 – 4:00    OPEN FLOOR / BUFFER             30 min
 ──────────────────────────────────────────────────────
                TOTAL                          240 min
 ```
+
+Hour 4 holds a 25-minute showcase, a 30-minute vision close, and 30 minutes of open floor. The buffer absorbs slippage from earlier in the day and gives attendees a graceful exit if they have adjacent sessions.
 
 ---
 
@@ -58,112 +63,132 @@ TIME           MOVEMENT                        DURATION
 
 ### 1. Arrival + Environment Setup (0:00 – 0:20)
 
-Participants self-seat. Screens show a single QR code and one instruction: open the URL and sign in with GitHub. While they settle, they authenticate into the AI creation environment — so setup happens during the natural drift of arrival, not as a dedicated task.
+Participants self-seat. Screens show a single QR code and one instruction: open the URL on your laptop and sign in with GitHub. They authenticate into the AI creation environment while they settle, so setup happens during the natural drift of arrival rather than as a dedicated task.
 
-The lead facilitator delivers a 3-minute story pitch at 0:10. Not a rules explanation — a hook: "In the next 40 minutes your table is going to handle a live cyber incident. You don't need to know the rules. Your IM will handle everything."
+The lead facilitator delivers a 3-minute story pitch at 0:10. Not a rules explanation, a hook: "In the next 40 minutes your table is going to handle a live cyber incident. You don't need to know the rules. Your IM will handle everything."
 
 Role cards distributed by table IMs. Each player introduces themselves in-character (30 seconds each).
 
 **Facilitator notes:**
 
 - Late arrivals welcome through 0:30. IMs catch them up in-character.
-- Environment setup must be self-service — facilitators should not be helping with logins during this phase. QR code URL must work first-try on a phone browser.
+- Environment setup is self-service. Facilitators should not be helping with logins during this phase.
+- A printed paper sign-in path exists as emergency fallback for anyone whose OAuth fails (see Failure Modes).
 
 ---
 
 ### 2. Immersion (0:20 – 1:00)
 
-Participants play a compressed M&M session using one of the zero-prep scenarios (GaboonGrabber or FakeBat). These are fully scripted — IMs need no prior preparation beyond a single read-through.
+Participants play a compressed M&M session using one of the zero-prep scenarios (GaboonGrabber or FakeBat). These are fully scripted; IMs need no prior preparation beyond a single read-through.
 
-The session runs through **Round 1 in full** (~25 minutes), then the IM narrates the malmon reveal from Round 2 (~5 minutes) rather than playing it out. This gives participants the complete experience arc — hook, investigation, decision point, and the "oh wow, this is based on a real malware family" moment — without requiring the full 90-120 minute runtime.
+The session runs through **Round 1 in full** (~25 minutes), then the IM narrates the malmon reveal from Round 2 (~5 minutes) rather than playing it out. This gives participants the complete experience arc — hook, investigation, decision point, and the "oh wow, this is based on a real malware family" moment — without requiring the full 90–120 minute runtime.
 
-**Why compress here:** participants do not need to finish a scenario to understand how to design one. Round 1 shows them everything load-bearing: how the organisation and hook create urgency, how NPCs work, how clue prompts drive investigation, how decision points feel. Rounds 2 and 3 add resolution mechanics and type effectiveness — useful gameplay, but not necessary for the creation task ahead.
+**Why compress here:** participants do not need to finish a scenario to understand how to design one. Round 1 shows them what matters: how the organisation and hook create urgency, how NPCs work, how clue prompts drive investigation, how decision points feel. Rounds 2 and 3 add resolution mechanics and type effectiveness, useful gameplay but not necessary for the creation task ahead.
 
-**Scenario selection:** GaboonGrabber (phishing / credential theft) or FakeBat (malvertising / downloader). Both are beginner-tier, fully scripted, and require zero prep. Run the same scenario across all tables for a shared debrief in Movement 4.
+**Scenario distribution:** if facilitator capacity allows, run GaboonGrabber at half the tables and FakeBat at the other half. Mixing the play experience yields more diverse PR submissions in the creation block. Tables that played a phishing scenario will tend to design phishing-flavored scenarios. The Dissection movement still works because the structural fields are identical across scenarios.
 
 ---
 
 ### 3. Break (1:00 – 1:10)
 
-Physical reset. IMs post a single notecard per table on the wall: malmon name, outcome, and "the moment everything went sideways." Participants browse other tables' cards during the break — seeds the "what would I do differently" mindset and functions as a lightweight harvest of the play experience.
+Physical reset. IMs post a single notecard per table on the wall: malmon name, outcome, and "the moment everything went sideways." Participants browse other tables' cards during the break, seeding the "what would I do differently" mindset and lightweight-harvesting the play experience.
 
 ---
 
 ### 4. Dissection (1:10 – 1:25)
 
-The highest-leverage 15 minutes in the workshop. Lead facilitator displays the scenario card they just played on screen and walks through every field: organisation, hook, pressure, NPCs, secrets, villain plan. "You just played this. Here's what was on my cheat sheet. Remember when [NPC] called about [event]? That was this field. The reason [plot point] happened? That was this secret."
+The highest-leverage 15 minutes in the workshop. Lead facilitator displays the scenario card they just played on screen and walks through every field: organization, hook, pressure, NPCs, secrets, villain plan. "You just played this. Here's what was on my cheat sheet. Remember when [NPC] called about [event]? That was this field. The reason [plot point] happened? That was this secret."
 
-Demystification is the bridge from player to designer. Participants leave this movement understanding that the experience they just had was constructed from a small number of deliberate choices — choices they are about to make themselves.
+Participants leave this movement understanding that the experience they just had was constructed from a small number of deliberate choices, choices they are about to make themselves.
 
-Close with a single sentence: "You're going to build one of these in the next 50 minutes. The AI will guide you through every field."
+Close with a single sentence: "You're going to build one of these in the next 50 minutes. The AI will guide you through every field and validate it the moment you submit."
 
 ---
 
 ### 5. AI-Guided Creation (1:25 – 2:15)
 
-Participants open the AI creation environment (already authenticated from Movement 1) and begin. The AI conducts a structured interview: organisation, stakes, hook, NPCs, secrets, villain plan. Participants answer in plain language. The AI generates a valid scenario in the repository format.
+Participants open the AI creation environment (already authenticated from Movement 1) and begin. The AI conducts a structured interview: organization, stakes, hook, NPCs, secrets, villain plan. Participants answer in plain language. The AI generates a valid scenario in the repository format.
 
 The session is split:
 
 - **Sprint 1 (25 min, 1:25–1:50):** AI interview, first complete draft generated.
-- **Peer check-in (5 min, 1:50–1:55):** Participants show their neighbour the draft. Written exchange: one thing that works, one thing missing. Loud, social, brief energy reset.
-- **Sprint 2 (20 min, 1:55–2:15):** Iterate on feedback, finalise.
+- **Peer check-in (5 min, 1:50–1:55):** Participants show their neighbor the draft. Written exchange: one thing that works, one thing missing. Loud, social, brief energy reset.
+- **Sprint 2 (20 min, 1:55–2:15):** Iterate on feedback, finalize.
 
 **Why split with peer check-in:** 50 minutes of individual heads-down work at hour 2.5 is a documented energy valley in workshop design. The check-in breaks it into two focused sprints with a social moment between them.
 
-**What the AI does:** asks questions, accepts plain-language answers, formats the scenario correctly, validates completeness (minimum decision points, realistic threat actor, resolvable in 30 minutes of play), flags gaps. Participants do not need to know the scenario format.
+**What the AI does:** asks questions, accepts plain-language answers, formats the scenario correctly, runs the rubric (continuously, not just at submit) so participants get incremental feedback during the interview, runs the moderation pass for real-world identifiers, and prompts the participant for license consent before allowing PR submission.
+
+**Stuck path:** if a participant gets stuck, an explicit "Get a facilitator" button surfaces a flag on the facilitator dashboard. Participants are not expected to debug the AI. Facilitators have override authority on edge cases.
+
+**Diversity prompt:** the AI asks at least once during the interview, "What makes this scenario different from a generic [malmon-type] incident?" This nudges participants past the obvious template and yields more varied submissions.
 
 ---
 
 ### 6. Validate + Submit PR (2:15 – 2:35)
 
-The AI runs a final validation pass and, on approval, submits a pull request to the M&M repository with the participant's GitHub account. Name goes in the git history.
+The AI runs a final validation pass against the published rubric, performs the moderation check, captures license consent, and on approval submits a pull request.
 
-A live counter on the shared screen updates as PRs land. This is the moment of visible collective output — watching the number climb is the energy peak of the close.
+**In-workshop QA — three outcomes:**
 
-Facilitators circulate to unblock anyone stuck. Common issues: incomplete NPC motivations, villain plan lacking a second stage, organisation too generic. AI flags these — facilitators help resolve.
+| Outcome | What happens |
+|---|---|
+| **PASS** | PR auto-merges to the workshop's destination branch. Participant sees a confirmation moment: "Your scenario passed all 9 validation criteria. It's in." |
+| **NEEDS REVISION** | The rubric flags surface inline with specific guidance. Participant has the remainder of Sprint 2 (or this 20-min window) to address them and re-submit. If time runs out, the partial draft is saved and the participant has a 7-day window to complete and submit post-workshop. |
+| **DECLINE** | Reserved for moderation failures (real org/person identifiers, sensitive incident details) or scope mismatches (not a malware scenario, not playable in the M&M format). The participant is given a clear reason and an option to revise post-workshop or accept the decline. |
+
+This QA model produces three benefits:
+
+1. **No backlog.** The quality bar is enforced live; the maintainer doesn't absorb a queue of PRs the week after DEF CON.
+2. **Immediate feedback.** Participants whose work needs iteration find out in the room, with time to fix it.
+3. **Visible project rigor.** Quality gates become part of the workshop demonstration.
+
+The model requires a machine-runnable validation rubric. See the Validation Rubric section.
+
+**PR template** auto-fills with: scenario metadata, author handle, AI-disclosure note ("Drafted with AI assistance via the DEF CON 2026 workshop tool"), and the license-consent confirmation captured during creation.
+
+**Live workshop dashboard** updates as PRs land. The dashboard tracks scenarios passed, scenarios in revision, distinct industries represented, malmons referenced, and a live list of PR titles, surfacing creative diversity alongside submission volume.
+
+Facilitators circulate to unblock anyone in NEEDS REVISION. Common issues: incomplete NPC motivations, villain plan lacking a second stage, organisation too generic. The AI surfaces these with specific guidance, and facilitators help interpret and resolve.
 
 ---
 
-### 7. Showcase (2:35 – 3:20)
+### 7. Showcase (2:35 – 3:00)
 
-Lead facilitator reads submitted scenarios aloud — one from each table, selected for variety or quality. The room hears what was built in 50 minutes with AI assistance.
+Lead facilitator highlights 4–6 submitted scenarios, selected for variety across industries, malmon types, and creative angles. The pace is calibrated to attendee energy at hour 3.
 
-This movement serves two purposes: celebration of what the room produced, and live quality signal. If the scenarios read well, the AI tooling is validated. If they read rough, the facilitators take note for the post-workshop retrospective and for improving the creation tool before future events.
+The showcase serves two purposes: celebration of what the room produced, and a live quality signal. Every featured scenario has already passed validation in Movement 6.
 
-Participants can photograph the PR counter and their own scenario on screen. Discord QR code is live.
+Participants can photograph the dashboard and their own scenario on screen. Discord QR code is live.
 
 ---
 
-### 8. Vision + Close (3:20 – 4:00)
+### 8. Vision + Close (3:00 – 3:30)
 
 Lead facilitator delivers the vision pitch: "Here's where this project was two years ago. Here's where it is today. With the scenarios you submitted this afternoon, here's where it could be next year."
 
-Sells the community trajectory, not just the event. Participants leave knowing their contribution has a destination.
+Frames the event as part of a longer community trajectory. Participants leave knowing their contribution has a destination.
 
-Followed by: Discord invite, next playtest date if known, open floor. Facilitators available for questions. Dice stay on tables — people linger and talk.
+Followed by Discord invite, next playtest date if known, and confirmation that PASS scenarios are already merged to the workshop branch and headed for `main`.
 
-**Post-workshop (facilitator responsibility):**
+### Open Floor / Buffer (3:30 – 4:00)
 
-- Review submitted PRs for quality. Merge what's solid, comment with feedback on what needs work.
-- Send Discord message thanking participants by scenario name.
-- Share photos from the session.
+Explicit unstructured time. Dice stay on tables. Facilitators available for questions. Absorbs schedule slip from earlier in the day. Attendees can leave gracefully if they have adjacent sessions.
 
 ---
 
 ## Technical Platform
 
-> **WIP:** Two approaches are in consideration. The choice will be made after a dry run, no later than 8 weeks before DEF CON.
+> **WIP:** Three approaches are in consideration. The decision will be made no later than T-8 weeks before DEF CON, after a dry run of the leading approach.
 
 ### Architecture Overview
 
-The creation pipeline has three components:
+The creation pipeline has four components:
 
-1. **AI layer** — conducts the scenario interview, generates structured output, validates completeness
-2. **GitHub layer** — authenticates participants, submits PRs on their behalf
-3. **Environment** — where participants interact with the AI (browser, CLI, or Codespace)
-
-The two approaches differ primarily in component 3 and the coupling between 1 and 3.
+1. **AI layer** — conducts the scenario interview, generates structured output, validates against the rubric continuously, runs the moderation pass.
+2. **GitHub layer** — authenticates participants via OAuth, submits PRs to the workshop branch on their behalf.
+3. **Environment** — where participants interact with the AI (browser, CLI, or Codespace).
+4. **LLM access layer** — handles API credentials and rate limits centrally; participants do not hold or rotate keys themselves.
 
 ---
 
@@ -173,82 +198,156 @@ Participants get a preconfigured cloud development environment (GitHub Codespace
 
 **How it works:**
 
-- Facilitator prepares a Codespace or Gitpod template with all dependencies pre-installed
-- Participants launch from a QR code, authenticate with GitHub
-- Claude Code skills guide them through scenario creation via slash commands
-- `gh` CLI (pre-authenticated) submits the PR
+- Facilitator prepares a Codespace or Gitpod template with all dependencies pre-installed.
+- Participants launch from a QR code, authenticate with GitHub.
+- Claude Code skills guide them through scenario creation via slash commands.
+- Pre-authenticated `gh` CLI submits the PR to the workshop branch.
 
-**Codespaces (primary):** GitHub product. Participants use their own GitHub free-tier accounts on the public M&M repo. Free tier includes 120 core-hours/month; a 2-hour session on a 2-core machine uses 4 core-hours — well within the limit. Cost to workshop organiser: ~$0. **Pricing confidence: 65%** — GitHub revises free tier terms periodically.
+**Codespaces (primary):** Free tier includes 120 core-hours/month. A 2-hour session on a 2-core machine uses 4 core-hours, well within the limit. Verify before T-8 weeks whether participants working in their own forks bill against their own quota (good) or whether direct work on the upstream repo bills against the repo owner.
 
-**Gitpod (EU alternative, Gitpod GmbH, Hamburg DE):** Historically comparable to Codespaces for public repos. However, Gitpod is actively sunsetting their hosted cloud service (gitpod.io) in favour of a self-hosted product (Gitpod Flex). Availability and pricing as of DEF CON 2026 are uncertain. **Pricing/availability confidence: 25%** — verify status closer to the event.
+**Gitpod (alternative):** Hosted cloud service is being sunset in favour of self-hosted Gitpod Flex. Availability and pricing as of August 2026 are uncertain. Verify status closer to the event.
 
-**Self-hosted (Coder, DevPod by Loft Labs Munich DE, code-server):** Open-source, runs on any EU infrastructure. Software is free; infrastructure cost for workshop day ~€5–15 on Hetzner or equivalent. Significant setup effort. **Cost confidence: 70%.**
-
-**Estimated probability this approach works end-to-end for the workshop: 0.60**
-
-Primary risks: DEFCON network reliability for Codespace launch; participant friction requiring Anthropic API access or shared key; locked to Claude as LLM.
+**Self-hosted (Coder, DevPod, code-server):** Open-source, runs on any infrastructure. Software is free; infrastructure cost for workshop day is modest. Significant setup effort.
 
 ---
 
 ### Option B: Custom Agent (Web App or CLI)
 
-A purpose-built tool — a web application or lightweight CLI — backed by any LLM API. Participants open a URL, authenticate GitHub via OAuth, chat with the agent, and the PR is submitted via the GitHub API. No Codespaces, no Claude Code, no dev environment required.
+A purpose-built tool — a web application or lightweight CLI — backed by any LLM API. Participants open a URL in their laptop browser, authenticate GitHub via OAuth, chat with the agent, and the PR is submitted via the GitHub API. No Codespaces, no Claude Code, no dev environment required.
 
 **How it works:**
 
-- A hosted web app (or installable CLI) wraps an LLM API with M&M-specific tool definitions
-- Participants authenticate via GitHub OAuth on first load
-- The agent interviews them, generates the scenario, submits the PR via GitHub API
-- Hosted on EU infrastructure (Hetzner, Fly.io EU region, etc.)
+- A hosted web app wraps an LLM-agnostic backend with M&M-specific tool definitions.
+- Participants authenticate via GitHub OAuth on first load.
+- The agent interviews them, generates the scenario, runs validation + moderation, captures license consent, submits the PR via the GitHub API.
 
-This approach removes the dev environment layer entirely. Participant requirement reduces to: a browser and a GitHub account.
+This approach removes the dev environment layer entirely. Participant requirement reduces to: a laptop with a browser and a GitHub account.
 
-It is also **LLM-agnostic** — the agent can be backed by Claude, GPT-4.1, Gemini, or any OpenAI-compatible API. The LLM can be swapped without changing participant experience.
+It is also **LLM-agnostic**. The backend can be Claude, GPT-4.1, Gemini, or any OpenAI-compatible API, and the LLM can be swapped without changing participant experience.
 
-**Infrastructure cost:** ~€5–20/month for a lightweight EU-hosted app during development + workshop day. **Cost confidence: 70%.**
+Primary risk: build effort is greater than Option A. This is a real software project, not a configuration exercise.
 
-**Estimated probability this approach works end-to-end for the workshop: 0.75**
+---
 
-Higher probability than Option A primarily due to lower participant friction and fewer infrastructure dependencies. Primary risk: build effort is greater than Option A.
+### Option C: Hybrid (B as primary, A as optional depth path)
+
+Option B's web app handles the AI interview UX for all participants. Option A's pre-warmed Codespace is offered as an *optional* deeper-edit path for participants who finish their first draft early or want to test their scenario locally before submission. Most participants never touch the Codespace.
+
+**Why hybrid:** the median participant should not need a dev environment at all. The motivated participant should not be capped at the web app's editing affordances. Option C gives Option B's accessibility floor and Option A's depth ceiling without fully building both.
 
 ---
 
 ### LLM Options
 
-Applies to both approaches. All credible options are US-based — tested EU alternatives (Mistral et al.) are not competitive for structured creative generation at the quality required.
+Applies to all three approaches. All credible options at the required quality bar are US-based.
 
 | Model | Input | Output | Workshop cost ~40 pax | Quality | Notes |
 |-------|-------|--------|-----------------------|---------|-------|
-| **Claude Sonnet 4.6** | $3/MTok | $15/MTok | ~$1–3 | Excellent | Required for Option A. Recommended for Option B if familiarity is a factor. Native schema enforcement. |
-| **Claude Haiku 4.5** | $1/MTok | $5/MTok | ~$0.35–1 | Excellent | Same schema quality as Sonnet at 3× lower cost. Strong budget option for Option B. |
-| **GPT-4.1** | $2/MTok | $8/MTok | ~$0.65–2 | Excellent | Strongest non-Claude option. 1M context. Option B only. |
-| **Gemini 2.5 Pro** | $1.25/MTok | $10/MTok | ~$0.55–2 | Excellent | Best price at frontier quality. Google Cloud EU data residency available. Option B only. |
-| **Llama 3.3 70B (Groq)** | $0.59/MTok | $0.79/MTok | ~$0.20–0.50 | Acceptable | Already in stack. Ultra-fast inference. 5–20% parse failure on complex schemas without constrained decoding — needs retry logic. Not recommended as sole primary. |
+| **Claude Sonnet 4.6** | $3/MTok | $15/MTok | ~$1–3 | Excellent | Required for Option A. Strong default for B/C. Native schema enforcement. |
+| **Claude Haiku 4.5** | $1/MTok | $5/MTok | ~$0.35–1 | Excellent | Same schema quality as Sonnet at 3× lower cost. Recommended primary for B/C. |
+| **GPT-4.1** | $2/MTok | $8/MTok | ~$0.65–2 | Excellent | Strongest non-Claude option. 1M context. Option B/C only. |
+| **Gemini 2.5 Pro** | $1.25/MTok | $10/MTok | ~$0.55–2 | Excellent | Best price at frontier quality. Option B/C only. |
+| **Llama 3.3 70B (Groq)** | $0.59/MTok | $0.79/MTok | ~$0.20–0.50 | Acceptable | Ultra-fast inference. 5–20% parse failure on complex schemas without constrained decoding. Not recommended as sole primary. |
 
-**All pricing confidence: 70%** — verified from official sources April 2026, but API pricing changes frequently.
+API pricing as of April 2026; verify before the event.
 
 ---
 
-### What "Preconfigured" Means
+## Validation Rubric
 
-Regardless of approach, participants should arrive at a state where:
+> **Critical artifact.** This rubric is the AI's success spec, the project's quality floor, and the in-workshop QA contract. Underspecified rubric = mediocre PRs slipping through PASS, or quality submissions being incorrectly flagged.
 
-- GitHub is authenticated (write access to fork or branch)
-- The scenario template is pre-loaded in context
-- The M&M scenario format is encoded in the AI's instructions
-- The PR target (branch, repo, file path) is pre-set
-- Validation criteria are baked in (the AI knows what makes a complete scenario)
+The rubric draws on the project's published scenario quality blueprint and its accompanying pattern library. Both must be finalized in the project repo before T-8 weeks so the workshop tool can run the rubric programmatically.
 
-Participants provide only the creative content. Everything else is handled.
+A submitted scenario passes validation only when it satisfies all of the following:
+
+1. **Organisation specified.** Industry, size, regulatory context. Generic placeholders rejected ("a tech company" — no).
+2. **Hook present.** A specific, time-bounded inciting event delivered to the players.
+3. **Pressure source named.** What constraint forces decisions — regulator, customer, executive, attacker timeline, or some combination.
+4. **At least 2 NPCs with motivations.** Each NPC has a stated reason they're talking to the players, not just a name.
+5. **At least 2 secrets / hidden facts.** Information players don't have at the start that becomes available through investigation.
+6. **Villain plan with at least 2 stages.** The malmon's actions across rounds must escalate or shift, not just repeat.
+7. **Resolvable in 30 minutes of play.** Stated decision points exist and can plausibly be reached in compressed runtime.
+8. **No real-world identifiers.** Moderation pass clean (see Content Moderation).
+9. **License consent captured.** Participant has affirmatively agreed to CC NC-SA terms.
+
+Each criterion is binary (pass/fail). The AI surfaces failed criteria with specific guidance ("Your second NPC has no stated motivation — what does Sarah from Accounting want?"). Participants iterate until pass or escalate to a facilitator via the stuck button.
+
+The rubric is published in the workshop repo before the event so participants and facilitators can preview, and so the AI's validation logic is visible and reviewable.
+
+---
+
+## Content Moderation + License Consent
+
+### Moderation pass
+
+Before any PR is submitted, the AI runs a moderation pass on the scenario content:
+
+- **Real organisation names** detected via a curated allowlist (fictional / template orgs only) and disallowlist (Fortune 500, recently breached entities, known IR clients of the participant's domain).
+- **Real people's names** detected against public-figure and known-victim lists. Generic first names allowed.
+- **Recent IOCs** — domain names, IP addresses, file hashes — pattern-matched and flagged.
+- **Industry-specific identifiers** — real medical device model numbers, SCADA system identifiers, CVE numbers tied to current exploitation campaigns.
+
+Flags route to a facilitator dashboard. The participant sees a friendly prompt: "Your scenario references [X] — could we use a fictional name instead?" Facilitators can override flags case-by-case.
+
+This is not a perfect filter. It is a first pass that catches obvious problems and flags ambiguous ones for human review.
+
+### License consent
+
+Before PR submission, the AI presents an explicit confirmation:
+
+> "By submitting, you license this scenario under CC NC-SA 4.0 and confirm that:
+>
+> - The content does not include confidential information from your current or former employer.
+> - The content does not identify real people without their permission.
+> - You authored the creative content; AI assistance is acknowledged in the PR description."
+
+The participant must check the box to proceed. The confirmation text is captured and included in the PR template.
+
+---
+
+## Connectivity Posture
+
+The 2025 workshop ran without connectivity issues on conference Wi-Fi. The DEF CON network is not assumed to be hostile in this design.
+
+**Design implications:**
+
+- **Laptop required.** Participants bring a laptop with browser access to GitHub. This is the prerequisite, full stop.
+- **Cellular hotspot as backup.** Participants who choose not to connect to conference Wi-Fi can tether to their phone. The AI tool's bandwidth profile is kept modest so cellular is viable.
+- **No assumption that participants share a network.** Each session is independent. The dashboard pulls from the GitHub API rather than any local LAN service.
+- **Printed materials are emergency-only.** See Failure Modes. They exist as a recovery path for technical difficulties.
+
+---
+
+## Failure Modes + Graceful Degradation
+
+The 50-minute creation block is the highest-stakes window in the workshop. Failures during it should degrade gracefully, not collapse the participant's experience.
+
+| Failure | Mitigation |
+|---------|------------|
+| GitHub OAuth fails for one participant | Printed paper sign-in: name, email, GitHub handle on a card. Facilitator manually attaches their submission post-event. |
+| LLM service outage | Printed scenario template (markdown skeleton with prompts) handed out as emergency fallback. Participant fills it manually, submits as PR via web upload at the end. Used only when the primary path is unrecoverable, not as a parallel experience. |
+| AI flags scenario as incomplete and participant disagrees | Stuck button → facilitator override → PR proceeds. |
+| Participant runs out of time mid-creation | AI auto-saves drafts to the participant's GitHub account. Participant receives the link by email and can complete + PR post-workshop within a stated 7-day window. |
+| GitHub API outage during submission window | Drafts saved locally + emailed to participant. Submission window extends to 7 days post-event. Live dashboard updates with manual entries. |
+| Workshop dashboard fails | Facilitators read submission count off GitHub directly. Showcase still works. |
+
+The design principle: **no single infrastructure failure leaves a participant with nothing**. Every failure mode has a path to "you have a draft saved, you can submit later."
 
 ---
 
 ## Participant Prerequisites
 
-- GitHub account
-- A device with a browser
+- A GitHub account
+- A laptop with a browser
 
-Nothing else. No laptop required if mobile GitHub OAuth works for the chosen approach. No git knowledge. No prior M&M experience. No programming ability.
+That's it. No git knowledge required, no programming ability required, no prior M&M experience required.
+
+**Accessibility:**
+
+- The AI interview supports keyboard-only navigation.
+- Scenario text generation can be read aloud via the web app's screen-reader-friendly markup.
+- Workshop materials (zero-prep scenarios, dissection slide) are available in English. International participants are welcome; facilitators can pair internationally fluent volunteer IMs with non-native-English tables on request.
 
 ---
 
@@ -258,32 +357,77 @@ Nothing else. No laptop required if mobile GitHub OAuth works for the chosen app
 |------|-------|-----------------|
 | Lead facilitator | 1 | Story pitch, whole-room debrief, showcase MC, vision close. Does NOT run a table. |
 | Table IM | 2 minimum | Run tables during Immersion. Circulate and unblock during Creation. |
-| Volunteer IMs | +1 per 8 attendees above 24 | Brief 30 min before doors. Run one table each. |
+| Volunteer IMs | +1 per 8 attendees above 24 | Briefed remotely the week before (60 min). Run one table each. |
 
 **Prep timeline:**
 
 | When | What |
 |------|------|
-| T-8 weeks | Scenario selection finalised. AI creation tool dry run. |
-| T-6 weeks | Decision: Option A or Option B. Build begins. |
-| T-4 weeks | All IMs: read zero-prep scenario cover to cover. Run one practice session. |
-| T-2 weeks | Full dry run with real participants. Scenarios produced evaluated for quality. If rough: add iteration sprint, reduce showcase. |
-| T-1 week | Print materials. Test environment end-to-end. |
-| T-30 min | Room setup, tables, QR codes on screen, brief volunteer IMs. |
+| T-12 weeks | Initial planning. Scenario selection draft. First dry run of the leading technical approach. Validation rubric finalized in repo. |
+| T-8 weeks | Decision gate: Option A, B, or C. Validation rubric published in repo. AI creation tool build begins. |
+| T-6 weeks | First-pass AI tool ready. Scenario selection finalised. |
+| T-4 weeks | All paid IMs: read zero-prep scenario cover to cover. Run one practice session. |
+| T-2 weeks | Full dry run with real participants. Scenarios produced evaluated for quality against the rubric. |
+| T-1 week | Volunteer IM remote briefing call (60 min). Print emergency materials. End-to-end test. |
+| T-0 (-30 min) | Room setup, tables, QR codes on screen, paper sign-in fallback ready. |
+
+Volunteer IMs receive a remote 60-minute briefing the week before. Tabletop facilitation for six strangers is not a same-day skill transfer.
+
+---
+
+## Post-Workshop Workflow
+
+The workshop's quality bar is enforced live in Movement 6. The post-workshop window handles celebration, late submissions, and the merge from the workshop branch to `main`.
+
+### Merge to main (T+1 to T+7)
+
+PRs that received PASS during the workshop are already on the workshop branch. Within a week, the maintainer reviews them in batch and merges to `main`. Most need no further changes; they were validated against the rubric live.
+
+### Late submissions (T+1 to T+7)
+
+Participants who didn't finish during the workshop have a 7-day window to complete their scenario and submit. The AI tool remains available, and the same validation rubric applies. PASS submissions in this window also merge to `main`.
+
+### Communication
+
+A Discord post on T+1 thanks participants by scenario name, lists merged scenarios, and reminds anyone in the late-submission window of their deadline. A second post on T+7 celebrates the final count of merged scenarios.
+
+---
+
+## Success Metrics
+
+| Metric | Target | Measured |
+|--------|--------|----------|
+| PRs PASS during workshop | ≥ 70% of attendees | T+0 |
+| PRs total (PASS + late completion within 7 days) | ≥ 85% of attendees | T+7 |
+| PRs merged to `main` | ≥ 90% of submitted | T+14 |
+| Participant Discord retention | ≥ 25% join Discord and remain at 30 days | T+30 |
+| Post-event participant survey NPS | ≥ +30 | T+7 |
+
+In-workshop PASS rate is the live quality signal. Late-completion rate validates the partial-submission path. Merge rate calibrates the rubric: too high suggests a loose rubric, too low suggests false-PASS conditions in the AI logic.
 
 ---
 
 ## What Needs to Be Built
 
-| Item | Approach | Effort | Priority |
-|------|----------|--------|----------|
-| AI creation tool (skills or agent) | A or B | High | Critical |
-| Codespace / Gitpod template | A only | Medium | Critical if A chosen |
-| Hosted web app + GitHub OAuth | B only | Medium | Critical if B chosen |
-| Scenario PR template (branch, path, format) | Both | Low | Critical |
-| AI validation criteria (completeness rubric) | Both | Low | Critical |
-| IM pacing cheat sheet (1 page) | Both | Low | Should |
-| QR code assets | Both | Trivial | Should |
-| Dry run participant recruitment (10–15 people, T-2 weeks) | Both | Medium | Should |
+| Item | Approach | Priority |
+|------|----------|----------|
+| AI creation tool (skills or agent) | A or B or C | Critical |
+| **Validation rubric (machine-runnable)** | Both | **Critical** |
+| **Content moderation pass (allow/disallow lists + heuristics)** | Both | **Critical** |
+| **LLM access layer (server-side credential isolation + rate limits)** | Both | Critical |
+| **License consent flow + PR template** | Both | Critical |
+| **In-workshop QA gate (PASS / NEEDS REVISION / DECLINE outcomes)** | Both | **Critical** |
+| **Failure mode handling (paper sign-in, printed template, draft auto-save)** | Both | Critical |
+| Codespace / Gitpod template | A and C | Critical if A or C chosen |
+| Hosted web app + GitHub OAuth | B and C | Critical if B or C chosen |
+| Workshop branch + PR template | Both | Critical |
+| Workshop dashboard (PASS, NEEDS REVISION, industries, malmons) | Both | Should |
+| IM pacing cheat sheet (1 page) | Both | Should |
+| Volunteer IM remote briefing materials (60-min call) | Both | Should |
+| QR code assets | Both | Should |
+| Dry run participant recruitment (10–15 people, T-2 weeks) | Both | Should |
+| Late-submission Discord reminder template | Both | Should |
 
-**Decision gate:** Option A vs Option B must be decided no later than T-6 weeks (approximately mid-June 2026 for a DEF CON August event).
+The in-workshop QA gate depends on a machine-runnable validation rubric finalized before T-8 weeks.
+
+**Decision gate:** Option A vs B vs C must be decided no later than T-8 weeks before DEF CON.


### PR DESCRIPTION
## Summary

Substantial revision of `docs/workshops/defcon-2026-syllabus.md` incorporating contributor feedback. The doc now reflects an in-workshop QA model, laptop-required connectivity posture, rebalanced hour 4, and a unified T-8 weeks decision gate.

## Major changes

- **In-workshop QA gate at submission time.** PASS auto-merges to a workshop branch; NEEDS REVISION lets participants iterate within remaining time or in a 7-day post-workshop window; DECLINE handles moderation failures with reasoning. Removes the post-event review backlog.
- **Connectivity posture revised.** Laptop required (no mobile-first claim). Printed materials are emergency fallback only.
- **Hour 4 timetable rebalanced.** 25-minute showcase, 30-minute vision close, 30-minute open floor buffer.
- **Decision gate at T-8 weeks** unified across all timeline references.
- **Validation rubric** promoted to its own section, marked critical.
- **Content moderation + license consent** steps added before PR submission.
- **LLM access** handled centrally rather than per-participant.

## Open questions for review

- The in-workshop QA model assumes the validation rubric is machine-runnable by T-8 weeks. Is that timeline workable?
- A 7-day late-submission window is the proposed default; happy to adjust.
- The PR target branch for workshop submissions (\`def-con-2026-workshop\`) is named in the doc but the branch itself isn't created yet — naming is open to revision.

Happy to iterate on any of this.