### PR TITLE
Ship: www-host PostHog instrumentation + UTM convention doc + workshop CTA

### DIFF
--- a/docs/marketing/UTM_CONVENTIONS.md
+++ b/docs/marketing/UTM_CONVENTIONS.md
@@ -1,0 +1,100 @@
+# UTM Conventions for Malware & Monsters
+
+Canonical UTM tagging pattern for every outbound URL we control — workshops, talks, social posts, newsletters, conference materials. Following this lets us answer "did the Toronto workshop drive site traffic?" with one PostHog filter, instead of guessing from total-visit deltas.
+
+## Pattern
+
+```
+https://malwareandmonsters.com/[path]?utm_source=<event>&utm_medium=<channel>&utm_campaign=<grouping>
+```
+
+### `utm_source` — where the URL was placed
+
+Slugified event or destination identifier. Stable, kebab-case, year-suffixed where relevant.
+
+| Context | Example `utm_source` |
+|---|---|
+| ISACA Toronto workshop, April 2026 | `isaca-toronto-2026` |
+| BSidesLV workshop | `bsides-las-vegas-2026` |
+| DEFCON workshop | `defcon-2026` |
+| Generic conference talk | `conf-<slug>-<year>` |
+| LinkedIn post | `linkedin` |
+| Newsletter | `newsletter-<list-name>` |
+| Discord announcement | `discord` |
+| Reddit post | `reddit-<sub>` |
+
+### `utm_medium` — channel type
+
+| Channel | `utm_medium` |
+|---|---|
+| In-person workshop attendees | `workshop` |
+| Conference talk slide | `talk` |
+| Booth handout / sticker | `booth` |
+| Social media post | `social` |
+| Email / newsletter | `email` |
+| Podcast / video description | `media` |
+
+### `utm_campaign` — optional grouping
+
+Use for thematic runs spanning multiple sources/mediums. Examples:
+
+- `apr13` — date-based for single-day events
+- `dnd-comparative` — content-themed
+- `2026-q2-launch` — temporal grouping
+
+Leave empty if not part of a campaign.
+
+## Examples
+
+- ISACA Toronto workshop, April 13 2026, slide CTA QR code:
+  ```
+  https://malwareandmonsters.com/?utm_source=isaca-toronto-2026&utm_medium=workshop&utm_campaign=apr13
+  ```
+
+- BSidesLV booth sticker:
+  ```
+  https://malwareandmonsters.com/?utm_source=bsides-las-vegas-2026&utm_medium=booth
+  ```
+
+- LinkedIn post linking to the IM Handbook:
+  ```
+  https://malwareandmonsters.com/im-handbook/?utm_source=linkedin&utm_medium=social&utm_campaign=im-handbook-launch
+  ```
+
+## How to generate
+
+Use `scripts/make-qr.sh`:
+
+```bash
+./scripts/make-qr.sh "https://malwareandmonsters.com/?utm_source=isaca-toronto-2026&utm_medium=workshop"
+```
+
+Outputs a PNG to `slides/_assets/qr/qr-<slug>.png` ready to embed in a Quarto slide.
+
+## How to measure
+
+PostHog auto-captures UTM params as `properties.$initial_utm_source`, `properties.$initial_utm_medium`, `properties.$initial_utm_campaign` on the first event for each session. Use the `query-run` MCP tool with HogQL:
+
+```sql
+SELECT
+  properties.$initial_utm_source AS source,
+  properties.$initial_utm_medium AS medium,
+  properties.$initial_utm_campaign AS campaign,
+  count(distinct properties.$session_id) AS sessions,
+  count() AS events
+FROM events
+WHERE event = '$pageview'
+  AND timestamp >= toDateTime('2026-04-13 00:00:00')
+  AND properties.$initial_utm_source IS NOT NULL
+GROUP BY source, medium, campaign
+ORDER BY sessions DESC
+```
+
+After a workshop ships with a UTM-tagged URL, save the corresponding insight in PostHog with the source name so it shows in dashboards.
+
+## Anti-patterns
+
+- **Don't** use spaces or non-ASCII in UTM values. Use kebab-case slugs.
+- **Don't** invent a new `utm_source` for every social post. `linkedin` covers all LinkedIn posts; `utm_campaign` differentiates them.
+- **Don't** use UTM tags on internal links (footer nav, in-page anchors). UTM is for external→site traffic only — internal UTM tags overwrite the original attribution and pollute the data.
+- **Don't** put `utm_*` in QR codes that point at `m.malwareandmonsters.com` (the PostHog reverse proxy). UTM tagging lives on the site URLs, not the analytics endpoint.

--- a/scripts/make-qr.sh
+++ b/scripts/make-qr.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# make-qr.sh — generate a QR code PNG from a URL, ready to embed in Quarto slides.
+#
+# Usage:
+#   ./scripts/make-qr.sh <url> [output.png]
+#
+# If output is omitted, defaults to slides/_assets/qr/qr-<slug>.png where <slug>
+# is derived from the URL's utm_source param (or, if absent, the URL host).
+#
+# Requires: qrencode (apt: qrencode | brew: qrencode | pacman: qrencode)
+#
+# See docs/marketing/UTM_CONVENTIONS.md for the canonical UTM tagging pattern.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <url> [output.png]" >&2
+  echo "Example: $0 'https://malwareandmonsters.com/?utm_source=isaca-toronto-2026&utm_medium=workshop'" >&2
+  exit 1
+fi
+
+URL="$1"
+OUTPUT="${2:-}"
+
+if ! command -v qrencode >/dev/null 2>&1; then
+  echo "Error: qrencode not installed. Install: apt install qrencode | brew install qrencode | pacman -S qrencode" >&2
+  exit 2
+fi
+
+# Derive slug from utm_source if present, else from URL hostname
+if [[ -z "$OUTPUT" ]]; then
+  SLUG=$(echo "$URL" | grep -oE 'utm_source=[^&]+' | head -1 | sed 's/utm_source=//' || true)
+  if [[ -z "$SLUG" ]]; then
+    SLUG=$(echo "$URL" | sed -E 's,^https?://([^/?]+).*,\1,' | tr '.' '-')
+  fi
+  # Sanitize slug
+  SLUG=$(echo "$SLUG" | tr -c 'a-zA-Z0-9-' '_' | sed 's/_*$//')
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+  OUTPUT="$REPO_ROOT/slides/_assets/qr/qr-${SLUG}.png"
+fi
+
+OUTPUT_DIR=$(dirname "$OUTPUT")
+mkdir -p "$OUTPUT_DIR"
+
+# Generate. -s 10 = pixel size per module (gives ~330x330 for typical URL).
+# -m 4  = quiet zone margin (4 modules).
+# -l H  = high error-correction (allows ~30% damage, useful for slide rendering).
+# -t PNG = output format.
+qrencode -s 10 -m 4 -l H -t PNG -o "$OUTPUT" "$URL"
+
+echo "Wrote QR code: $OUTPUT"
+echo "URL: $URL"
+echo "Size: $(wc -c < "$OUTPUT") bytes"

--- a/shared/includes/analytics.html
+++ b/shared/includes/analytics.html
@@ -1,6 +1,15 @@
 <script>
-    // Only load analytics on production domain (not testing site, localhost, or file://)
-    if (window.location.hostname === 'malwareandmonsters.com' && !window.location.pathname.startsWith('/preview-malmon/')) {
+    // Only load analytics on production domains (not testing site, localhost, or file://).
+    // Allow-list the apex AND www host. Browser autocomplete + social-card shares + copy-pasted
+    // URLs frequently land on www.malwareandmonsters.com; a strict apex-only check (the previous
+    // behavior) silently dropped every such visitor.
+    //
+    // DNT policy: respect_dnt is intentionally true. Privacy-aligned, EU-ethics-aligned, and
+    // costs some signal for visitors who explicitly opt out of tracking. This is a deliberate
+    // policy choice — do not flip to false without explicit decision. See PostHog issue
+    // discussion on malwareandmonsters.com analytics audit (issue #254).
+    var allowedHosts = ['malwareandmonsters.com', 'www.malwareandmonsters.com'];
+    if (allowedHosts.indexOf(window.location.hostname) !== -1 && !window.location.pathname.startsWith('/preview-malmon/')) {
       !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
       posthog.init('phc_R3mL0EYNpGlN3LACDBnT6ScRyaOcnHZqNpVDg7PCxlv', {
         api_host: 'https://m.malwareandmonsters.com',

--- a/slides/workshop-cta.qmd
+++ b/slides/workshop-cta.qmd
@@ -1,0 +1,70 @@
+---
+# slides/workshop-cta.qmd
+#
+# Reusable Quarto include for a "where to find us" slide at the start AND end
+# of every workshop / conference talk. Drives measurable traffic to
+# malwareandmonsters.com via UTM-tagged QR codes.
+#
+# Usage in a workshop deck:
+#
+#   ---
+#   title: "M&M Workshop"
+#   format: revealjs
+#   ---
+#
+#   ## ... your content slides ...
+#
+#   {{< include slides/workshop-cta.qmd >}}
+#
+# To customize for a specific event, override these variables before the include:
+#
+#   ```{r}
+#   #| echo: false
+#   utm_source <- "isaca-toronto-2026"
+#   utm_medium <- "workshop"
+#   utm_campaign <- "apr13"
+#   cta_url <- paste0("https://malwareandmonsters.com/?utm_source=", utm_source,
+#                     "&utm_medium=", utm_medium, "&utm_campaign=", utm_campaign)
+#   ```
+#
+# Then generate the QR PNG once (committed to slides/_assets/qr/):
+#
+#   ./scripts/make-qr.sh "https://malwareandmonsters.com/?utm_source=isaca-toronto-2026&utm_medium=workshop&utm_campaign=apr13"
+#
+# See docs/marketing/UTM_CONVENTIONS.md for the canonical UTM pattern.
+---
+
+## Get the handbooks {.smaller}
+
+::: {.columns}
+
+::: {.column width="55%"}
+
+**malwareandmonsters.com**
+
+Player Handbook · IM Handbook · Scenarios
+
+Free, open-source, Creative Commons NC-SA.
+
+Run your own M&M session at your team, your shop, your conference.
+
+Contributions welcome on GitHub: `klausagnoletti/malware-and-monsters`
+
+:::
+
+::: {.column width="45%"}
+
+![](_assets/qr/qr-default.png){fig-alt="QR code linking to malwareandmonsters.com" width="350"}
+
+*Scan with your phone camera.*
+
+:::
+
+:::
+
+<!--
+Replace `qr-default.png` with the event-specific QR (e.g. `qr-isaca-toronto-2026.png`)
+in the deck that includes this file. Generate via:
+  ./scripts/make-qr.sh "https://malwareandmonsters.com/?utm_source=<event>&utm_medium=workshop"
+The script auto-derives the filename from utm_source.
+-->


### PR DESCRIPTION
Three commits landed on \`testing\` weeks ago but never made it to \`main\`. As a result the live site has been missing:

- **\`51001b6\` (cherry-pick of \`9be7a20\`)** — PostHog www-host fix. Analytics on the \`www.\` host was being silently dropped.
- **\`5295375\` (cherry-pick of \`0730f5d\`)** — UTM conventions doc + QR generator script. Canonical guidance for tagging campaigns and printed material.
- **\`b0be54f\` (cherry-pick of \`08a235d\`)** — Reusable workshop CTA include for slide decks.

## Deliberately excluded

- \`62d41c2\` and \`f6281e4\` (DNT-disable) are NOT in this PR. \`respect_dnt: true\` stands — compliance wins. The decision to honour Do Not Track is locked.

## Stickers / UTM follow-up

Stickers already in the field are not UTM-tagged. The doc shipped here (\`docs/marketing/UTM_CONVENTIONS.md\`) is the canonical convention to apply on the **next** sticker batch — no retroactive change needed for existing stock.

## Verification

- Cherry-picks applied cleanly in commit order with no conflicts.
- Diff scope matches the three originals on \`testing\`.