### PR TITLE
feat(analytics): add Plausible alongside PostHog for parallel comparison

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -485,7 +485,7 @@ format:
       - file: shared/includes/analytics.html
       - text: |
           <!-- Security Headers -->
-          <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://m.malwareandmonsters.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https:; connect-src 'self' https://m.malwareandmonsters.com; frame-src 'self';">
+          <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://m.malwareandmonsters.com https://p.malwareandmonsters.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https:; connect-src 'self' https://m.malwareandmonsters.com https://p.malwareandmonsters.com; frame-src 'self';">
           <meta http-equiv="X-Content-Type-Options" content="nosniff">
           <meta http-equiv="Strict-Transport-Security" content="max-age=31536000; includeSubDomains; preload">
 

--- a/shared/includes/analytics.html
+++ b/shared/includes/analytics.html
@@ -15,5 +15,14 @@
         respect_dnt: true,
         capture_performance: false
       })
+
+      // Plausible CE on Hetzner (p.malwareandmonsters.com) — runs in parallel with PostHog for
+      // a comparison window. Cookieless, EU-hosted, fewer adblock hits than PostHog defaults.
+      var ps = document.createElement('script');
+      ps.defer = true;
+      ps.setAttribute('data-domain', 'malwareandmonsters.com');
+      ps.src = 'https://p.malwareandmonsters.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js';
+      document.head.appendChild(ps);
+      window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) };
     }
 </script>


### PR DESCRIPTION
Adds Plausible CE tracking (self-hosted at https://p.malwareandmonsters.com, Hetzner fsn1, EU) alongside existing PostHog. Runs in parallel ~2 weeks to ground-truth the adblock gap on the infosec audience. PostHog config unchanged. CSP extended for p.malwareandmonsters.com. Merging triggers publish.yml → GitHub Pages.