### PR TITLE
chore(ci): coalesce rapid-fire publish runs via concurrency group

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,13 @@ on:
   push:
     branches: [main]
 
+# Coalesce rapid-fire pushes (e.g. multiple PRs merged within minutes) into
+# a single deploy. The newest commit always wins; older in-flight builds are
+# cancelled so we don't briefly publish an intermediate state.
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: true
+
 name: Build and Deploy to GitHub Pages
 
 jobs:


### PR DESCRIPTION
Two-line addition: `concurrency: { group: pages-deploy, cancel-in-progress: true }` on publish.yml. Newer push cancels any older in-flight build for the same group. Stops the duplicate-build behavior we just hit when #280 and #281 merged within seconds.