### PR TITLE
chore(robots): block AI/LLM crawlers and aggressive scrapers

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -17,7 +17,7 @@ Allow: /
 User-agent: Baiduspider
 Allow: /
 
-# Block known bad bots
+# Block known bad bots (SEO / backlink scrapers)
 User-agent: MJ12bot
 Disallow: /
 
@@ -25,6 +25,73 @@ User-agent: AhrefsBot
 Disallow: /
 
 User-agent: SemrushBot
+Disallow: /
+
+User-agent: DotBot
+Disallow: /
+
+User-agent: BLEXBot
+Disallow: /
+
+User-agent: DataForSeoBot
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+# Block AI / LLM training and answer-engine crawlers
+User-agent: GPTBot
+Disallow: /
+
+User-agent: OAI-SearchBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: meta-externalagent
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: YouBot
 Disallow: /
 
 # Sitemap location


### PR DESCRIPTION
## Why
Plausible and PostHog diverged on traffic counts. Root cause: bot/crawler traffic that PostHog counts and Plausible filters by default. A crawler wave started ~June 14, dominated by datacenter regions (CN/HK/SG), spidering the whole `/im-handbook/` tree. Proof: stripping CN/HK/SG from PostHog (416 pv) lands within 0.5% of Plausible's bot-filtered 418 pv for the same week.

## What
Extends the existing 'block known bad bots' section of `robots.txt` with:
- AI / LLM training + answer-engine crawlers: GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-Web, anthropic-ai, CCBot, Google-Extended, Applebot-Extended, Bytespider, PerplexityBot, Amazonbot, meta-externalagent, cohere-ai, Diffbot, Omgilibot, ImagesiftBot, YouBot
- Aggressive SEO / scraper bots: DotBot, BLEXBot, DataForSeoBot, PetalBot

## Honest scope
robots.txt is advisory. The well-behaved LLM/SEO crawlers honor it (real win on crawl load and analytics noise). The spoofed-user-agent datacenter scrapers behind the June-14 spike will likely ignore it. For clean human numbers, Plausible remains the source of truth; PostHog stays useful as the raw lens that surfaced this wave.

Search engines (Google/Bing/DuckDuckGo/Baidu) remain explicitly allowed.